### PR TITLE
Deprecated instanciate in favor of instantiation (correct grammatical form)

### DIFF
--- a/src/Molecule/MolComponentFactory.class.st
+++ b/src/Molecule/MolComponentFactory.class.st
@@ -572,30 +572,38 @@ MolComponentFactory >> dirtyComponents [
 ]
 
 { #category : #'private - code generation' }
-MolComponentFactory >> generateComponentAccessorsFor: aSymbol withList: aCollection in: aComponent suffix: suffix [
+MolComponentFactory >> generateComponentAccessorsFor: aSymbol withList: aCollection in: aComponent suffix: suffix [ [
 	| selector sourceCode sourceMethod method |
-	
-	aCollection copy do: [ :trait |
-		
-		selector := ('get' , trait printString , suffix) asSymbol.
-		sourceCode := self getSourceCodeFor: aSymbol trait: trait selector: selector.
-		(aComponent allSelectors includes: selector) ifFalse: [ 
-			aComponent compile: sourceCode contents classified: self class protocolForComponentAccess
-		] ifTrue: [ 
-			"if the method exist inspect this source code for search any difference between the existing required services and the requested required services"
-			"the selector must not be a parent"
-			(aComponent selectors includes: selector) ifTrue: [ 
-				method := aComponent >> selector.
-				sourceMethod := method sourceCode.
-				sourceMethod ifNotNil: [ 
-					sourceMethod ~= sourceCode contents ifTrue: [ 
-					"rewrite the method"
-						aComponent compile: sourceCode contents classified: self class protocolForComponentAccess 
+
+	aCollection copy do: [ :e | | trait |
+
+		"e can be another thing that a Trait, need to check nature of e before generate"
+		( e notNil and:[ e isTrait and:[( e isComponentServices or:[ e isComponentParameters or:[ e isComponentEvents ]])]]) ifTrue:[
+
+			trait := e.
+
+			selector := ('get' , trait printString , suffix) asSymbol.
+			sourceCode := self getSourceCodeFor: aSymbol trait: trait selector: selector.
+			(aComponent allSelectors includes: selector) ifFalse: [ 
+				aComponent compile: sourceCode contents classified: self class protocolForComponentAccess
+			] ifTrue: [ 
+				"if the method exist inspect this source code for search any difference between the existing required services and the requested required services"
+				"the selector must not be a parent"
+				(aComponent selectors includes: selector) ifTrue: [ 
+					method := aComponent >> selector.
+					sourceMethod := method sourceCode.
+					sourceMethod ifNotNil: [ 
+						sourceMethod ~= sourceCode contents ifTrue: [ 
+						"rewrite the method"
+							aComponent compile: sourceCode contents classified: self class protocolForComponentAccess 
+						]. 
 					]. 
 				]. 
 			]. 
-		]. 
+
+		].
 	]
+]
 ]
 
 { #category : #'code generation' }

--- a/src/Molecule/MolComponentFactory.class.st
+++ b/src/Molecule/MolComponentFactory.class.st
@@ -575,33 +575,26 @@ MolComponentFactory >> dirtyComponents [
 MolComponentFactory >> generateComponentAccessorsFor: aSymbol withList: aCollection in: aComponent suffix: suffix [
 	| selector sourceCode sourceMethod method |
 	
-	aCollection copy do: [ :e | | trait |
+	aCollection copy do: [ :trait |
 		
-		"e can be another thing that a Trait, need to check nature of e before generate"
-		( e notNil and:[ e isTrait and:[( e isComponentServices or:[ e isComponentParameters or:[ e isComponentEvents ]])]]) ifTrue:[
-			
-			trait := e.
-		
-			selector := ('get' , trait printString , suffix) asSymbol.
-			sourceCode := self getSourceCodeFor: aSymbol trait: trait selector: selector.
-			(aComponent allSelectors includes: selector) ifFalse: [ 
-				aComponent compile: sourceCode contents classified: self class protocolForComponentAccess
-			] ifTrue: [ 
-				"if the method exist inspect this source code for search any difference between the existing required services and the requested required services"
-				"the selector must not be a parent"
-				(aComponent selectors includes: selector) ifTrue: [ 
-					method := aComponent >> selector.
-					sourceMethod := method sourceCode.
-					sourceMethod ifNotNil: [ 
-						sourceMethod ~= sourceCode contents ifTrue: [ 
-						"rewrite the method"
-							aComponent compile: sourceCode contents classified: self class protocolForComponentAccess 
-						]. 
+		selector := ('get' , trait printString , suffix) asSymbol.
+		sourceCode := self getSourceCodeFor: aSymbol trait: trait selector: selector.
+		(aComponent allSelectors includes: selector) ifFalse: [ 
+			aComponent compile: sourceCode contents classified: self class protocolForComponentAccess
+		] ifTrue: [ 
+			"if the method exist inspect this source code for search any difference between the existing required services and the requested required services"
+			"the selector must not be a parent"
+			(aComponent selectors includes: selector) ifTrue: [ 
+				method := aComponent >> selector.
+				sourceMethod := method sourceCode.
+				sourceMethod ifNotNil: [ 
+					sourceMethod ~= sourceCode contents ifTrue: [ 
+					"rewrite the method"
+						aComponent compile: sourceCode contents classified: self class protocolForComponentAccess 
 					]. 
 				]. 
 			]. 
-		
-		].
+		]. 
 	]
 ]
 

--- a/src/Molecule/MolComponentImpl.trait.st
+++ b/src/Molecule/MolComponentImpl.trait.st
@@ -77,7 +77,7 @@ MolComponentImpl classSide >> instanciate [
 		deprecated: 'Use instantiate'
 		transformWith:
 		'`@receiver instanciate' -> '`@receiver instantiate'.
-	^ MolComponentManager default homeServices instanciateComponent: self
+	^ self instantiate
 ]
 
 { #category : #'life cycle' }
@@ -87,9 +87,7 @@ MolComponentImpl classSide >> instanciate: aComponentName [
 		deprecated: 'Use instantiate:'
 		transformWith: '`@receiver instanciate: `@aComponentName'
 			-> '`@receiver instantiate: `@aComponentName'.
-	^ MolComponentManager default homeServices
-		  instanciateComponent: self
-		  named: aComponentName
+	^ self instantiate: aComponentName
 ]
 
 { #category : #'life cycle' }

--- a/src/Molecule/MolComponentImpl.trait.st
+++ b/src/Molecule/MolComponentImpl.trait.st
@@ -73,13 +73,37 @@ MolComponentImpl classSide >> haveOwnComponentType [
 { #category : #'life cycle' }
 MolComponentImpl classSide >> instanciate [
 
+	self
+		deprecated: 'Use instantiate'
+		transformWith:
+		'`@receiver instanciate' -> '`@receiver instantiate'.
 	^ MolComponentManager default homeServices instanciateComponent: self
 ]
 
 { #category : #'life cycle' }
 MolComponentImpl classSide >> instanciate: aComponentName [
 
-	^ MolComponentManager default homeServices instanciateComponent: self named: aComponentName
+	self
+		deprecated: 'Use instantiate:'
+		transformWith: '`@receiver instanciate: `@aComponentName'
+			-> '`@receiver instantiate: `@aComponentName'.
+	^ MolComponentManager default homeServices
+		  instanciateComponent: self
+		  named: aComponentName
+]
+
+{ #category : #'life cycle' }
+MolComponentImpl classSide >> instantiate [
+
+	^ MolComponentManager default homeServices instantiateComponent: self
+]
+
+{ #category : #'life cycle' }
+MolComponentImpl classSide >> instantiate: aComponentName [
+
+	^ MolComponentManager default homeServices
+		  instantiateComponent: self
+		  named: aComponentName
 ]
 
 { #category : #testing }

--- a/src/Molecule/MolComponentType.trait.st
+++ b/src/Molecule/MolComponentType.trait.st
@@ -21,84 +21,66 @@ Trait {
 { #category : #actions }
 MolComponentType classSide >> allConsumedEvents [
 	| collection |
-	
-	collection := (self consumedComponentEvents select:[ :e | e notNil and:[ e isTrait and:[ e isComponentEvents ]]]) asSet.
-	
+	collection := Set withAll: self consumedComponentEvents.
 	self allSuperclassesDo: [ :s | 
 		(s allTraits includes: MolComponentType) ifTrue: [ 
 				collection addAll: s consumedComponentEvents 
 		] ].
-
 	^ collection asOrderedCollection
 ]
 
 { #category : #actions }
 MolComponentType classSide >> allProducedEvents [
 	| collection |
-	
-	collection := (self producedComponentEvents select:[ :e | e notNil and:[ e isTrait and:[ e isComponentEvents ]]]) asSet.
-	
+	collection := Set withAll: self producedComponentEvents.
 	self allSuperclassesDo: [ :s | 
 		(s allTraits includes: MolComponentType) ifTrue: [ 
 				collection addAll: s producedComponentEvents 
 		] ].
-	
 	^ collection asOrderedCollection
 ]
 
 { #category : #actions }
 MolComponentType classSide >> allProvidedParameters [
 	| collection |
-	
-	collection := (self providedComponentParameters select:[ :e | e notNil and:[ e isTrait and:[ e isComponentParameters ]]]) asSet.
-	
+	collection := Set withAll: self providedComponentParameters.
 	self allSuperclassesDo: [ :s | 
 		(s allTraits includes: MolComponentType) ifTrue: [ 
 				collection addAll: s providedComponentParameters 
 		] ].
-	
 	^ collection asOrderedCollection 
 ]
 
 { #category : #actions }
 MolComponentType classSide >> allProvidedServices [
 	| collection |
-	
-	collection := (self providedComponentServices select:[ :e | e notNil and:[ e isTrait and:[ e isComponentServices ]]]) asSet.
-	
+	collection := Set withAll: self providedComponentServices.
 	self allSuperclassesDo: [ :s | 
 		(s allTraits includes: MolComponentType) ifTrue: [ 
 				collection addAll: s providedComponentServices 
 		] ].
-	
 	^ collection asOrderedCollection 
 ]
 
 { #category : #actions }
 MolComponentType classSide >> allUsedParameters [
 	| collection |
-	
-	collection := (self usedComponentParameters select:[ :e | e notNil and:[ e isTrait and:[ e isComponentParameters ]]]) asSet.
-	
+	collection := Set withAll: self usedComponentParameters.
 	self allSuperclassesDo: [ :s | 
 		(s allTraits includes: MolComponentType) ifTrue: [ 
 				collection addAll: s usedComponentParameters 
 		] ].
-	
 	^ collection asOrderedCollection 
 ]
 
 { #category : #actions }
 MolComponentType classSide >> allUsedServices [
 	| collection |
-	
-	collection := (self usedComponentServices select:[ :e | e notNil and:[ e isTrait and:[ e isComponentServices ]]]) asSet.
-	
+	collection := Set withAll: self usedComponentServices.
 	self allSuperclassesDo: [ :s | 
 		(s allTraits includes: MolComponentType) ifTrue: [ 
 				collection addAll: s usedComponentServices 
 		] ].
-	
 	^ collection asOrderedCollection 
 ]
 

--- a/src/Molecule/MolComponentType.trait.st
+++ b/src/Molecule/MolComponentType.trait.st
@@ -19,69 +19,93 @@ Trait {
 }
 
 { #category : #actions }
-MolComponentType classSide >> allConsumedEvents [
+MolComponentType classSide >> allConsumedEvents [ [
 	| collection |
-	collection := Set withAll: self consumedComponentEvents.
+
+	collection := (self consumedComponentEvents select:[ :e | e notNil and:[ e isTrait and:[ e isComponentEvents ]]]) asSet.
+
 	self allSuperclassesDo: [ :s | 
 		(s allTraits includes: MolComponentType) ifTrue: [ 
 				collection addAll: s consumedComponentEvents 
 		] ].
+
 	^ collection asOrderedCollection
+]
 ]
 
 { #category : #actions }
-MolComponentType classSide >> allProducedEvents [
+MolComponentType classSide >> allProducedEvents [ [
 	| collection |
-	collection := Set withAll: self producedComponentEvents.
+
+	collection := (self producedComponentEvents select:[ :e | e notNil and:[ e isTrait and:[ e isComponentEvents ]]]) asSet.
+
 	self allSuperclassesDo: [ :s | 
 		(s allTraits includes: MolComponentType) ifTrue: [ 
 				collection addAll: s producedComponentEvents 
 		] ].
+
 	^ collection asOrderedCollection
+]
 ]
 
 { #category : #actions }
-MolComponentType classSide >> allProvidedParameters [
+MolComponentType classSide >> allProvidedParameters [ [
 	| collection |
-	collection := Set withAll: self providedComponentParameters.
+
+	collection := (self providedComponentParameters select:[ :e | e notNil and:[ e isTrait and:[ e isComponentParameters ]]]) asSet.
+
 	self allSuperclassesDo: [ :s | 
 		(s allTraits includes: MolComponentType) ifTrue: [ 
 				collection addAll: s providedComponentParameters 
 		] ].
+
 	^ collection asOrderedCollection 
+]
 ]
 
 { #category : #actions }
-MolComponentType classSide >> allProvidedServices [
+MolComponentType classSide >> allProvidedServices [ [
 	| collection |
-	collection := Set withAll: self providedComponentServices.
+
+	collection := (self providedComponentServices select:[ :e | e notNil and:[ e isTrait and:[ e isComponentServices ]]]) asSet.
+
 	self allSuperclassesDo: [ :s | 
 		(s allTraits includes: MolComponentType) ifTrue: [ 
 				collection addAll: s providedComponentServices 
 		] ].
+
 	^ collection asOrderedCollection 
+]
 ]
 
 { #category : #actions }
-MolComponentType classSide >> allUsedParameters [
+MolComponentType classSide >> allUsedParameters [ [
 	| collection |
-	collection := Set withAll: self usedComponentParameters.
+
+	collection := (self usedComponentParameters select:[ :e | e notNil and:[ e isTrait and:[ e isComponentParameters ]]]) asSet.
+
 	self allSuperclassesDo: [ :s | 
 		(s allTraits includes: MolComponentType) ifTrue: [ 
 				collection addAll: s usedComponentParameters 
 		] ].
+
 	^ collection asOrderedCollection 
+]
 ]
 
 { #category : #actions }
-MolComponentType classSide >> allUsedServices [
+MolComponentType classSide >> allUsedServices [ [
 	| collection |
-	collection := Set withAll: self usedComponentServices.
+
+	collection := (self usedComponentServices select:[ :e | e notNil and:[ e isTrait and:[ e isComponentServices ]]]) asSet.
+
 	self allSuperclassesDo: [ :s | 
 		(s allTraits includes: MolComponentType) ifTrue: [ 
 				collection addAll: s usedComponentServices 
 		] ].
+
 	^ collection asOrderedCollection 
+]
 ]
 
 { #category : #'accessing - events' }

--- a/src/Molecule/MolHomeServices.class.st
+++ b/src/Molecule/MolHomeServices.class.st
@@ -49,16 +49,15 @@ MolHomeServices >> activateComponent: aComponentClass named: aName [
 	waitingForActivation
 		remove: component
 		ifAbsent: [ ^ComponentAlreadyActivatedError signal: 'Component is already activated.' ].
-
+		
 	component componentConnector activateComponent.
-
-	"Manage connexion between components"
-	MolComponentManager default locatorServices resolveWaitingSubscriptions: component.
-
 	component componentActivate.
 	component triggerEvent: #activateComponent with: component.
 	
 	MolUtils log: aComponentClass printString , ' named: ' , aName printString , ' is activated.'.
+	
+	"manage connexion between components"
+	MolComponentManager default locatorServices resolveWaitingSubscriptions: component.
 	
 	^ component
 ]
@@ -71,59 +70,68 @@ MolHomeServices >> addDeployedComponent: aComponentClass [
 { #category : #private }
 MolHomeServices >> checkInstanciationOfComponent: aComponentClass named: aComponentName [
 
+	self deprecated: 'Use checkInstantiationOfComponent: named:'
+		transformWith: '`@receiver checkInstanciationOfComponent: `@aComponentClass named: `@aComponentName' -> '`@receiver checkInstantiationOfComponent: `@aComponentClass named: `@aComponentName'.
+	^ self checkInstantiationOfComponent: aComponentClass named: aComponentName
+]
+
+{ #category : #private }
+MolHomeServices >> checkInstantiationOfComponent: aComponentClass named: aComponentName [
+
 	| deployed component overridedTypes |
-	aComponentName ifNil: [ 
+	aComponentName ifNil: [
 		^ WrongComponentNameError new messageText:
-			  'Can not instanciate a component without name' ].
-		
+			  'Can not instantiate a component without name' ].
+
 	aComponentName isSymbol ifFalse: [
 		^ WrongComponentNameError new messageText:
-			  'Can not instanciate a component with a name wish is not a symbol' ].
-		
-	deployed := self deployedComponents at: aComponentClass ifAbsent: [ 
-		        ^ ComponentNotDeployedError new messageText:
-			          'Can not instanciate a non deployed component' ].
-	deployed at: aComponentName ifPresent: [ :e | 
-		e ifNotNil: [ 
+			  'Can not instantiate a component with a name wish is not a symbol' ].
+
+	deployed := self deployedComponents at: aComponentClass ifAbsent: [
+		            ^ ComponentNotDeployedError new messageText:
+			              'Can not instantiate a non deployed component' ].
+	deployed at: aComponentName ifPresent: [ :e |
+		e ifNotNil: [
 			^ ComponentAlreadyExistsError new messageText:
-				  'Can not instanciate a component with the same name of another component, please change the name of the component' ] ].
-		
+				  'Can not instantiate a component with the same name of another component, please change the name of the component' ] ].
+
 	component := MolComponentManager default locatorServices
-		        searchComponentTypeImplementorFor: aComponentClass componentType
-		        named: aComponentName.
-	component ifNotNil: [ 
+		             searchComponentTypeImplementorFor:
+		             aComponentClass componentType
+		             named: aComponentName.
+	component ifNotNil: [
 		^ ComponentAlreadyExistsError new messageText:
-			  'Can not instanciate a component with the same type and name of another component, please change the name of the component' ].
-		
-	aComponentClass componentType allProvidedServices do: [ :e | 
+			  'Can not instantiate a component with the same type and name of another component, please change the name of the component' ].
+
+	aComponentClass componentType allProvidedServices do: [ :e |
 		(MolComponentManager default locatorServices
 			 searchServicesProviderFor: e
-			 named: aComponentName) isNotFoundServices ifFalse: [ 
+			 named: aComponentName) isNotFoundServices ifFalse: [
 			^ ComponentProvidedServicesAlreadyExistsError new messageText:
-				  'Can not instanciate a component with the same services and name of another component, please change the name of the component' ] ].
-		
-	aComponentClass componentType allProvidedParameters do: [ :e | 
+				  'Can not instantiate a component with the same services and name of another component, please change the name of the component' ] ].
+
+	aComponentClass componentType allProvidedParameters do: [ :e |
 		(MolComponentManager default locatorServices
 			 searchParametersProviderFor: e
-			 named: aComponentName) isNotFoundParameters ifFalse: [ 
+			 named: aComponentName) isNotFoundParameters ifFalse: [
 			^ ComponentProvidedParametersAlreadyExistsError new messageText:
-				  'Can not instanciate a component with the same parameters and name of another component, please change the name of the component' ] ].
-		
-	aComponentClass isOverrideComponentType ifTrue: [ 
+				  'Can not instantiate a component with the same parameters and name of another component, please change the name of the component' ] ].
+
+	aComponentClass isOverrideComponentType ifTrue: [
 		overridedTypes := aComponentClass overridedComponentTypes.
-		overridedTypes do: [ :type | 
-			type allProvidedServices do: [ :e | 
+		overridedTypes do: [ :type |
+			type allProvidedServices do: [ :e |
 				(MolComponentManager default locatorServices
 					 searchServicesProviderFor: e
-					 named: aComponentName) isNotFoundServices ifFalse: [ 
+					 named: aComponentName) isNotFoundServices ifFalse: [
 					^ ComponentProvidedServicesAlreadyExistsError new messageText:
-						  '(Inheritance problem) Can not instanciate a component with the same services and name of another component, please change the name of the component' ] ].
-			type allProvidedParameters do: [ :e | 
+						  '(Inheritance problem) Can not instantiate a component with the same services and name of another component, please change the name of the component' ] ].
+			type allProvidedParameters do: [ :e |
 				(MolComponentManager default locatorServices
 					 searchParametersProviderFor: e
-					 named: aComponentName) isNotFoundParameters ifFalse: [ 
+					 named: aComponentName) isNotFoundParameters ifFalse: [
 					^ ComponentProvidedServicesAlreadyExistsError new messageText:
-						  '(Inheritance problem) Can not instanciate a component with the same parameters and name of another component, please change the name of the component' ] ] ] ].
+						  '(Inheritance problem) Can not instantiate a component with the same parameters and name of another component, please change the name of the component' ] ] ] ].
 	^ nil
 ]
 
@@ -146,39 +154,73 @@ MolHomeServices >> instanceOf: aClass named: aName [
 
 { #category : #'life cycle' }
 MolHomeServices >> instanciateAllComponents [
-	self deployedComponents keysDo: [ :aClass | self instanciateComponent: aClass ]
+
+	self deprecated: 'Use instantiateAllComponents'
+		transformWith: '`@receiver instanciateAllComponents' -> '`@receiver instantiateAllComponents'.
+	self instantiateAllComponents
 ]
 
 { #category : #'life cycle' }
 MolHomeServices >> instanciateComponent: aComponentClass [
 
-	^ self instanciateComponent: aComponentClass named: MolUtils defaultComponentName
+	self deprecated: 'Use instantiateComponent:'
+		transformWith: '`@receiver instanciateComponent: `@aComponentClass' -> '`@receiver instantiateComponent: `@aComponentClass'.
+	^ self instantiateComponent: aComponentClass
 ]
 
 { #category : #'life cycle' }
 MolHomeServices >> instanciateComponent: aComponentClass named: aName [
+
+	self deprecated: 'Use instantiateComponent: named:'
+		transformWith: '`@receiver instanciateComponent: `@aComponentClass named: `@aName' ->'`@receiver instantiateComponent: `@aComponentClass named: `@aName'.
+	^ self instantiateComponent: aComponentClass named: aName
+]
+
+{ #category : #'life cycle' }
+MolHomeServices >> instantiateAllComponents [
+
+	self deployedComponents keysDo: [ :aClass |
+		self instantiateComponent: aClass ]
+]
+
+{ #category : #'life cycle' }
+MolHomeServices >> instantiateComponent: aComponentClass [
+
+	^ self instantiateComponent: aComponentClass named: MolUtils defaultComponentName
+]
+
+{ #category : #'life cycle' }
+MolHomeServices >> instantiateComponent: aComponentClass named: aName [
+
 	| error component connector deployed |
-	
-	aComponentClass ifNil:[^nil].
-	error := self checkInstanciationOfComponent: aComponentClass named: aName.
-	error ifNotNil:[error signal. ^nil].
-	
-	component := aComponentClass new componentName: aName; yourself.
-	MolUtils log: aComponentClass printString , ' named: ' , aName printString , ' is instanciated.'.
+	aComponentClass ifNil: [ ^ nil ].
+	error := self
+		         checkInstantiationOfComponent: aComponentClass
+		         named: aName.
+	error ifNotNil: [
+		error signal.
+		^ nil ].
+
+	component := aComponentClass new
+		             componentName: aName;
+		             yourself.
+	MolUtils log:
+		aComponentClass printString , ' named: ' , aName printString
+		, ' is instanciated.'.
 
 	deployed := self deployedComponents at: aComponentClass.
 	deployed at: component componentName put: component.
-	
+
 	"connect the component to the component model and initialize it"
 	connector := MolComponentConnector new.
 	component componentConnector: connector.
 	component componentInitialize.
 	component triggerEvent: #instanciateComponent with: component.
-	
+
 	"add the component to waiting activation list"
 	waitingForActivation add: component.
-	
-	^component
+
+	^ component
 ]
 
 { #category : #private }

--- a/src/Molecule/MolHomeServices.class.st
+++ b/src/Molecule/MolHomeServices.class.st
@@ -51,6 +51,10 @@ MolHomeServices >> activateComponent: aComponentClass named: aName [
 		ifAbsent: [ ^ComponentAlreadyActivatedError signal: 'Component is already activated.' ].
 		
 	component componentConnector activateComponent.
+	
+	"Manage connexion between components"
+	MolComponentManager default locatorServices resolveWaitingSubscriptions: component.
+	
 	component componentActivate.
 	component triggerEvent: #activateComponent with: component.
 	
@@ -68,11 +72,63 @@ MolHomeServices >> addDeployedComponent: aComponentClass [
 ]
 
 { #category : #private }
-MolHomeServices >> checkInstanciationOfComponent: aComponentClass named: aComponentName [
+MolHomeServices >> checkInstanciationOfComponent: aComponentClass named: aComponentName [ [
 
-	self deprecated: 'Use checkInstantiationOfComponent: named:'
-		transformWith: '`@receiver checkInstanciationOfComponent: `@aComponentClass named: `@aComponentName' -> '`@receiver checkInstantiationOfComponent: `@aComponentClass named: `@aComponentName'.
-	^ self checkInstantiationOfComponent: aComponentClass named: aComponentName
+	| deployed component overridedTypes |
+	aComponentName ifNil: [ 
+		^ WrongComponentNameError new messageText:
+			  'Can not instanciate a component without name' ].
+		
+	aComponentName isSymbol ifFalse: [
+		^ WrongComponentNameError new messageText:
+			  'Can not instanciate a component with a name wish is not a symbol' ].
+		
+	deployed := self deployedComponents at: aComponentClass ifAbsent: [ 
+		        ^ ComponentNotDeployedError new messageText:
+			          'Can not instanciate a non deployed component' ].
+	deployed at: aComponentName ifPresent: [ :e | 
+		e ifNotNil: [ 
+			^ ComponentAlreadyExistsError new messageText:
+				  'Can not instanciate a component with the same name of another component, please change the name of the component' ] ].
+		
+	component := MolComponentManager default locatorServices
+		        searchComponentTypeImplementorFor: aComponentClass componentType
+		        named: aComponentName.
+	component ifNotNil: [ 
+		^ ComponentAlreadyExistsError new messageText:
+			  'Can not instanciate a component with the same type and name of another component, please change the name of the component' ].
+		
+	aComponentClass componentType allProvidedServices do: [ :e | 
+		(MolComponentManager default locatorServices
+			 searchServicesProviderFor: e
+			 named: aComponentName) isNotFoundServices ifFalse: [ 
+			^ ComponentProvidedServicesAlreadyExistsError new messageText:
+				  'Can not instanciate a component with the same services and name of another component, please change the name of the component' ] ].
+		
+	aComponentClass componentType allProvidedParameters do: [ :e | 
+		(MolComponentManager default locatorServices
+			 searchParametersProviderFor: e
+			 named: aComponentName) isNotFoundParameters ifFalse: [ 
+			^ ComponentProvidedParametersAlreadyExistsError new messageText:
+				  'Can not instanciate a component with the same parameters and name of another component, please change the name of the component' ] ].
+		
+	aComponentClass isOverrideComponentType ifTrue: [ 
+		overridedTypes := aComponentClass overridedComponentTypes.
+		overridedTypes do: [ :type | 
+			type allProvidedServices do: [ :e | 
+				(MolComponentManager default locatorServices
+					 searchServicesProviderFor: e
+					 named: aComponentName) isNotFoundServices ifFalse: [ 
+					^ ComponentProvidedServicesAlreadyExistsError new messageText:
+						  '(Inheritance problem) Can not instanciate a component with the same services and name of another component, please change the name of the component' ] ].
+			type allProvidedParameters do: [ :e | 
+				(MolComponentManager default locatorServices
+					 searchParametersProviderFor: e
+					 named: aComponentName) isNotFoundParameters ifFalse: [ 
+					^ ComponentProvidedServicesAlreadyExistsError new messageText:
+						  '(Inheritance problem) Can not instanciate a component with the same parameters and name of another component, please change the name of the component' ] ] ] ].
+	^ nil
+]
 ]
 
 { #category : #private }

--- a/src/Molecule/MolHomeServices.class.st
+++ b/src/Molecule/MolHomeServices.class.st
@@ -60,9 +60,6 @@ MolHomeServices >> activateComponent: aComponentClass named: aName [
 	
 	MolUtils log: aComponentClass printString , ' named: ' , aName printString , ' is activated.'.
 	
-	"manage connexion between components"
-	MolComponentManager default locatorServices resolveWaitingSubscriptions: component.
-	
 	^ component
 ]
 

--- a/src/Molecule/MolUtils.class.st
+++ b/src/Molecule/MolUtils.class.st
@@ -152,11 +152,28 @@ MolUtils class >> isComponentOrComponentClass: anObject [
 { #category : #testing }
 MolUtils class >> isInstanciateComponentOf: aClass [
 
-	^ self isInstanciateComponentOf: aClass named: self defaultComponentName
+	self deprecated: 'Use isInstantiateComponentOf:'
+		transformWith: '`@receiver isInstanciateComponentOf: `@aClass' -> '`@receiver isInstantiateComponentOf: `@aClass'.
+	^ self isInstantiateComponentOf: aClass
 ]
 
 { #category : #testing }
 MolUtils class >> isInstanciateComponentOf: aClass named: aName [
+
+	self deprecated: 'Use isInstantiateComponentOf: named: '
+		transformWith: '`@receiver isInstanciateComponentOf: `@aClass named: `@aName' -> '`@receiver isInstantiateComponentOf: `@aClass named: `@aName'.
+	^ self isInstantiateComponentOf: aClass named: aName
+]
+
+{ #category : #testing }
+MolUtils class >> isInstantiateComponentOf: aClass [
+
+	^ self isInstantiateComponentOf: aClass named: self defaultComponentName
+]
+
+{ #category : #testing }
+MolUtils class >> isInstantiateComponentOf: aClass named: aName [
+
 	^ (MolComponentManager default homeServices instanceOf: aClass named: aName) notNil
 ]
 


### PR DESCRIPTION
Deprecated instanciate in favor of instantiation (correct grammatical form). Same for instanciation which needs to be replaced by instantiation.
This commit fixes https://github.com/OpenSmock/Molecule/issues/97