### PR TITLE
Adds two new visualization options to Molecule

### DIFF
--- a/src/Molecule-IDE-Tests/MolImplementationsTest.class.st
+++ b/src/Molecule-IDE-Tests/MolImplementationsTest.class.st
@@ -1,0 +1,60 @@
+Class {
+	#name : #MolImplementationsTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'clockImplementations',
+		'geoPosImplementations'
+	],
+	#category : #'Molecule-IDE-Tests-Cases'
+}
+
+{ #category : #running }
+MolImplementationsTest >> setUp [
+
+	super setUp.
+
+	"Put here a common initialization logic for tests"
+	clockImplementations := MolImplementations new.
+	clockImplementations type: MolMyClockComponent.
+
+	geoPosImplementations := MolImplementations new.
+	geoPosImplementations type: MolGeoPosEquipmentType.
+]
+
+{ #category : #running }
+MolImplementationsTest >> testBrowseButtonActivated [
+
+	| enabled |
+	clockImplementations implementationList selectItem:
+		MolMyClockComponentImpl.
+	enabled := clockImplementations buttonBrowse isEnabled.
+
+	self assert: [ enabled ]
+]
+
+{ #category : #running }
+MolImplementationsTest >> testFilter [
+
+	| implementations |
+	geoPosImplementations implementationList filterListItems: 'gps'.
+	implementations := geoPosImplementations implementationList items.
+
+	self assert: [ implementations size = 2 ]
+]
+
+{ #category : #running }
+MolImplementationsTest >> testSelectingImplementation [
+
+	clockImplementations implementationList selectItem: MolMyClockComponentImpl.
+
+	self assert: [
+		clockImplementations implementationList selectedItem
+		= MolMyClockComponentImpl ]
+]
+
+{ #category : #running }
+MolImplementationsTest >> testTitle [
+
+	self assert: [
+		clockImplementations title = 'MolMyClockComponent Implementations' ]
+]

--- a/src/Molecule-IDE-Tests/MolInterfacesTest.class.st
+++ b/src/Molecule-IDE-Tests/MolInterfacesTest.class.st
@@ -1,0 +1,54 @@
+Class {
+	#name : #MolInterfacesTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'localTimeEvents'
+	],
+	#category : #'Molecule-IDE-Tests-Cases'
+}
+
+{ #category : #running }
+MolInterfacesTest >> setUp [
+
+	super setUp.
+
+	"Put here a common initialization logic for tests"
+	localTimeEvents := MolInterfaces new.
+	localTimeEvents interface: MolMyLocalTimeEvents.
+]
+
+{ #category : #running }
+MolInterfacesTest >> testBrowseButtonActivated [
+
+	| enabled |
+	localTimeEvents requiredList selectItem: MolMyAlarmComponent.
+	enabled := localTimeEvents buttonBrowse isEnabled.
+	self assert: [ enabled ]
+]
+
+{ #category : #running }
+MolInterfacesTest >> testRequiredAnd [
+
+	localTimeEvents dropList selectItem: 'Required AND Offered'.
+	self assert: [ localTimeEvents requiredList items size = 0 ]
+]
+
+{ #category : #running }
+MolInterfacesTest >> testRequiredOr [
+	"no need to select an option since OR is selected by default"
+
+	self assert: [ localTimeEvents requiredList items size = 2 ]
+]
+
+{ #category : #running }
+MolInterfacesTest >> testRequiredXor [
+
+	localTimeEvents dropList selectItem: 'Required XOR Offered'.
+	self assert: [ localTimeEvents requiredList items size = 2 ]
+]
+
+{ #category : #running }
+MolInterfacesTest >> testTitle [
+
+	self assert: [ localTimeEvents title = 'MolMyLocalTimeEvents events' ]
+]

--- a/src/Molecule-IDE-Tests/MyClass.class.st
+++ b/src/Molecule-IDE-Tests/MyClass.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #MyClass,
+	#superclass : #Object,
+	#category : #'Molecule-IDE-Tests-Cases'
+}

--- a/src/Molecule-IDE/MolClassesCmdCommand.class.st
+++ b/src/Molecule-IDE/MolClassesCmdCommand.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #MolClassesCmdCommand,
 	#superclass : #MolCmdCommand,
-	#category : #'Molecule-IDE-Menus'
+	#category : #'Molecule-IDE'
 }
 
 { #category : #testing }

--- a/src/Molecule-IDE/MolCmdCommand.class.st
+++ b/src/Molecule-IDE/MolCmdCommand.class.st
@@ -6,7 +6,6 @@ Class {
 	#superclass : #CmdCommand,
 	#instVars : [
 		'selectedItems',
-		'items',
 		'executionResult'
 	],
 	#category : #'Molecule-IDE-Menus'

--- a/src/Molecule-IDE/MolDefineComponentCmdCommand.class.st
+++ b/src/Molecule-IDE/MolDefineComponentCmdCommand.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #MolDefineComponentCmdCommand,
 	#superclass : #MolClassesCmdCommand,
-	#category : #'Molecule-IDE-Menus'
+	#category : #'Molecule-IDE'
 }
 
 { #category : #activation }

--- a/src/Molecule-IDE/MolImplementations.class.st
+++ b/src/Molecule-IDE/MolImplementations.class.st
@@ -1,0 +1,63 @@
+Class {
+	#name : #MolImplementations,
+	#superclass : #MolOptions,
+	#instVars : [
+		'selectedType'
+	],
+	#category : #'Molecule-IDE-Tools'
+}
+
+{ #category : #initialization }
+MolImplementations >> buttonBrowseAction [
+	"an implementation needs to be selected in order to browse it"
+
+	| item |
+	item := implementationList selectedItem.
+
+	item ifNotNil: [
+		buttonBrowse enable.
+		item browse ]
+]
+
+{ #category : #initialization }
+MolImplementations >> connectPresenters [
+	"enables the Browse button if an implementation is selected"
+
+	implementationList whenSelectionChangedDo: [
+		implementationList selectedItem ifNotNil: [ buttonBrowse enable ] ]
+]
+
+{ #category : #initialization }
+MolImplementations >> defaultLayout [
+
+	^ SpBoxLayout newVertical
+		  add: implementationList;
+		  addLast: actionBar;
+		  yourself
+]
+
+{ #category : #initialization }
+MolImplementations >> initializePresenters [
+
+	super initializePresenters.
+
+	implementationList := SpFilteringListDoubleClickPresenter new.
+	implementationList displayIcon: [ :elem |
+		self iconNamed: elem systemIconName ]
+]
+
+{ #category : #initialization }
+MolImplementations >> title [
+
+	^ selectedType asString , ' Implementations'
+]
+
+{ #category : #initialization }
+MolImplementations >> type: aType [
+	"when the Type Trait is given, loads the list"
+
+	"only one Type can be selected in the System Browser at a time"
+
+	selectedType := aType.
+	implementationList items: (self listImplementations: selectedType)
+]

--- a/src/Molecule-IDE/MolInspectComponentRunningInstancesCmdCommand.class.st
+++ b/src/Molecule-IDE/MolInspectComponentRunningInstancesCmdCommand.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #MolInspectComponentRunningInstancesCmdCommand,
 	#superclass : #MolClassesCmdCommand,
-	#category : #'Molecule-IDE-Menus'
+	#category : #'Molecule-IDE'
 }
 
 { #category : #activation }

--- a/src/Molecule-IDE/MolInspectInterfacesImplementationsCmdCommand.class.st
+++ b/src/Molecule-IDE/MolInspectInterfacesImplementationsCmdCommand.class.st
@@ -1,0 +1,47 @@
+Class {
+	#name : #MolInspectInterfacesImplementationsCmdCommand,
+	#superclass : #MolInterfaceCmdCommand,
+	#category : #'Molecule-IDE-Tools'
+}
+
+{ #category : #activation }
+MolInspectInterfacesImplementationsCmdCommand class >> browserMenuActivation [
+	<classAnnotation>
+	^CmdContextMenuActivation byItemOf: MolCmdMenuGroup for: ClyFullBrowserClassContext.
+]
+
+{ #category : #accessing }
+MolInspectInterfacesImplementationsCmdCommand >> defaultMenuIconName [
+
+	^ 'glamorousInspect'
+]
+
+{ #category : #accessing }
+MolInspectInterfacesImplementationsCmdCommand >> defaultMenuItemName [
+
+	^ 'See Component users'
+]
+
+{ #category : #accessing }
+MolInspectInterfacesImplementationsCmdCommand >> description [
+
+	^ 'Shows in a window users of the selected interface (Events, Parameters or Services)'
+]
+
+{ #category : #accessing }
+MolInspectInterfacesImplementationsCmdCommand >> execute [
+
+	| selectedInterface emptyArray interface |
+	selectedInterface := self selectedInterfaceClass.
+
+	interface := MolInterfaces new.
+	emptyArray := Array new: 0.
+
+	"condition and ifTrue: are executed only if multiple Traits were/are selected in the System Browser, since this option only supports one Type selected at a time"
+	selectedInterface = emptyArray
+		ifFalse: [ selectedInterface := selectedInterface at: 1 ]
+		ifTrue: [
+		selectedInterface := (selectedItems at: 1) browserItem actualObject ].
+	interface interface: selectedInterface.
+	interface open
+]

--- a/src/Molecule-IDE/MolInspectTypeImplementationsCmdCommand.class.st
+++ b/src/Molecule-IDE/MolInspectTypeImplementationsCmdCommand.class.st
@@ -1,0 +1,47 @@
+Class {
+	#name : #MolInspectTypeImplementationsCmdCommand,
+	#superclass : #MolTypeCmdCommand,
+	#category : #'Molecule-IDE-Tools'
+}
+
+{ #category : #activation }
+MolInspectTypeImplementationsCmdCommand class >> browserMenuActivation [
+	<classAnnotation>
+	^CmdContextMenuActivation byItemOf: MolCmdMenuGroup for: ClyFullBrowserClassContext.
+]
+
+{ #category : #accessing }
+MolInspectTypeImplementationsCmdCommand >> defaultMenuIconName [
+
+	^ 'glamorousInspect'
+]
+
+{ #category : #accessing }
+MolInspectTypeImplementationsCmdCommand >> defaultMenuItemName [
+
+	^ 'See Component Implementations'
+]
+
+{ #category : #accessing }
+MolInspectTypeImplementationsCmdCommand >> description [
+
+	^ 'Shows implementations of this Molecule Type'
+]
+
+{ #category : #accessing }
+MolInspectTypeImplementationsCmdCommand >> execute [
+
+	| selectedType implem emptyArray |
+	selectedType := self selectedTypeClass.
+
+	implem := MolImplementations new.
+	emptyArray := Array new: 0.
+
+	"condition and ifTrue: are executed only if multiple Traits were/are selected in the System Browser, since this option only supports one Type selected at a time"
+	selectedType = emptyArray
+		ifFalse: [ selectedType := selectedType at: 1 ]
+		ifTrue: [
+		selectedType := (selectedItems at: 1) browserItem actualObject ].
+	implem type: selectedType.
+	implem open
+]

--- a/src/Molecule-IDE/MolInterfaceCmdCommand.class.st
+++ b/src/Molecule-IDE/MolInterfaceCmdCommand.class.st
@@ -1,0 +1,40 @@
+Class {
+	#name : #MolInterfaceCmdCommand,
+	#superclass : #MolCmdCommand,
+	#category : #'Molecule-IDE-Tools'
+}
+
+{ #category : #testing }
+MolInterfaceCmdCommand class >> canBeExecutedInContext: aToolContext [
+
+	| list selectedItem selected |
+	(super canBeExecutedInContext: aToolContext) ifFalse: [ ^ false ].
+	aToolContext selectedItems ifEmpty: [ ^ false ].
+
+	selectedItem := aToolContext selectedItems at: 1.
+	selected := selectedItem browserItem actualObject name.
+
+	"find all interfaces"
+	list := SystemNavigation default allClasses select: [ :c |
+		        c isTrait and: [
+			        c isComponentEvents or:
+				        (c isComponentParameters or: c isComponentServices) ] ].
+
+	"return if selected object is in list of component"
+	^ list includes: (self class environment at: selected asSymbol)
+]
+
+{ #category : #'api - accessing' }
+MolInterfaceCmdCommand >> selectedClass [
+
+	^ (selectedItems collect: [ :p | p browserItem actualObject ])
+]
+
+{ #category : #'as yet unclassified' }
+MolInterfaceCmdCommand >> selectedInterfaceClass [
+	"this method returns the class in the System Browser that is an interface (Events/Parameters/Services)"
+
+	^ self selectedClass select: [ :c |
+		  c isComponentEvents or:
+			  (c isComponentParameters or: c isComponentServices) ]
+]

--- a/src/Molecule-IDE/MolInterfaces.class.st
+++ b/src/Molecule-IDE/MolInterfaces.class.st
@@ -1,0 +1,397 @@
+Class {
+	#name : #MolInterfaces,
+	#superclass : #MolOptions,
+	#instVars : [
+		'selectedInterface',
+		'requiredList',
+		'offeredList',
+		'dropList',
+		'typeInterface',
+		'servicesProvidedList',
+		'eventsConsumedList',
+		'parametersUsedList',
+		'servicesUsedList',
+		'eventsProducedList',
+		'parametersProvidedList',
+		'listImplementationBoth',
+		'eventsConsumed',
+		'parametersUsed',
+		'servicesUsed',
+		'eventsProduced',
+		'parametersProvided',
+		'servicesProvided',
+		'implemList',
+		'menuList'
+	],
+	#category : #'Molecule-IDE-Tools'
+}
+
+{ #category : #initialization }
+MolInterfaces >> addTrait: trait IfInterfaceCorrespondsIn: interfaceList forList: interfaceForScreenList [
+	"adds the interfaces that appear in the relevant parts of the component contract to lists in order to show them after using requiredList and offeredList"
+
+	interfaceList ifNotNil: [
+		interfaceList do: [ :interface |
+			interface = selectedInterface ifTrue: [
+				interfaceForScreenList add: trait ] ] ]
+]
+
+{ #category : #adding }
+MolInterfaces >> addTypesInInterfaceList: trait [
+	"add a Trait to the lists if it corresponds to a part of their component contract"
+
+	typeInterface = 'Events' ifTrue: [
+		eventsConsumed := trait allConsumedEvents.
+		self
+			addTrait: trait
+			IfInterfaceCorrespondsIn: eventsConsumed
+			forList: eventsConsumedList.
+
+		eventsProduced := trait allProducedEvents.
+		self
+			addTrait: trait
+			IfInterfaceCorrespondsIn: eventsProduced
+			forList: eventsProducedList ].
+
+	typeInterface = 'Parameters' ifTrue: [
+		parametersUsed := trait allUsedParameters.
+		self
+			addTrait: trait
+			IfInterfaceCorrespondsIn: parametersUsed
+			forList: parametersUsedList.
+
+		parametersProvided := trait allProvidedParameters.
+		self
+			addTrait: trait
+			IfInterfaceCorrespondsIn: parametersProvided
+			forList: parametersProvidedList ].
+
+	typeInterface = 'Services' ifTrue: [
+		servicesUsed := trait allUsedServices.
+		self
+			addTrait: trait
+			IfInterfaceCorrespondsIn: servicesUsed
+			forList: servicesUsedList.
+
+		servicesProvided := trait allProvidedServices.
+		self
+			addTrait: trait
+			IfInterfaceCorrespondsIn: servicesProvided
+			forList: servicesProvidedList ]
+]
+
+{ #category : #adding }
+MolInterfaces >> addTypesInInterfaceLists [
+
+	selectedInterface = '' ifTrue: [ ^ self ].
+	
+	(MolUtils requiredTypes: selectedInterface) do: [ :trait |
+		self addTypesInInterfaceList: trait ].
+
+	(MolUtils offeredTypes: selectedInterface) do: [ :trait |
+		self addTypesInInterfaceList: trait ]
+]
+
+{ #category : #'as yet unclassified' }
+MolInterfaces >> andMode [
+	"if a Type appears in both columns (is both required and offered), show it in both columns"
+	"doesn't show it in either if it only appears once"
+
+	self emptyLists.
+
+	self addTypesInInterfaceLists.
+
+	self require: eventsConsumedList andOffer: eventsProducedList.
+	self require: parametersUsedList andOffer: parametersProvidedList.
+	self require: servicesUsedList andOffer: servicesProvidedList.
+
+	self fillRequiredAndOfferedLists.
+
+	self applyFilter
+]
+
+{ #category : #initialization }
+MolInterfaces >> applyFilter [
+	"used when changing boolean operator modes in order to conserve the filters typed, for both the required and offered interfaces"
+
+	| requiredListFilter offeredListFilter |
+	requiredList ifNotNil: [
+		requiredListFilter := requiredList filterText.
+		offeredListFilter := offeredList filterText.
+
+		requiredList applyFilter: requiredListFilter.
+		offeredList applyFilter: offeredListFilter ]
+]
+
+{ #category : #initialization }
+MolInterfaces >> buttonBrowseAction [
+	"an implementation needs to be selected in order to browse it. The last selected one (for both lists) being the one browsed"
+
+	| item |
+	item := implementationList selectedItem.
+	item ifNotNil: [ item browse ]
+]
+
+{ #category : #initialization }
+MolInterfaces >> connectPresenters [
+	"enables the Browse button if a Type is selected, disables it if another mode is chosen since the lists are reset and the selection could point to nothing in particular"
+
+	dropList whenSelectionChangedDo: [ buttonBrowse disable ].
+
+	self enableBrowseButton: requiredList.
+	self enableBrowseButton: offeredList
+]
+
+{ #category : #initialization }
+MolInterfaces >> defaultLayout [
+
+	^ SpBoxLayout newVertical
+		  add: 'Component Types which are using this interface:'
+		  expand: false;
+		  add: dropList expand: false;
+		  add: (SpBoxLayout newLeftToRight
+				   add: (SpBoxLayout newVertical
+						    add: 'Required' expand: false;
+						    add: requiredList;
+						    yourself);
+				   add: SpBoxLayout newLeftToRight width: 5 yourself;
+				   add: (SpBoxLayout newVertical
+						    add: 'Offered' expand: false;
+						    add: offeredList;
+						    yourself);
+				   yourself);
+		  addLast: actionBar;
+		  yourself
+]
+
+{ #category : #initialization }
+MolInterfaces >> determineTypeInterface [
+	"determines the type of the selected interface (Events, Parameters or Services) using the relevant Molecule methods (isComponent[Events/Parameters/Services])"
+
+	| events parameters services |
+	events := 'Events'.
+	parameters := 'Parameters'.
+	services := 'Services'.
+
+	selectedInterface isComponentEvents ifTrue: [
+		typeInterface := events ].
+	selectedInterface isComponentParameters ifTrue: [
+		typeInterface := parameters ].
+	selectedInterface isComponentServices ifTrue: [
+		typeInterface := services ]
+]
+
+{ #category : #initialization }
+MolInterfaces >> dropList [
+	"used for test purposes"
+
+	^ dropList
+]
+
+{ #category : #initialization }
+MolInterfaces >> emptyLists [
+	"since the implementations change when switching from one boolean operator to another, the lists of implementations need to be reset"
+
+	"is also used to initialize them since this method is called at the start of required[And/Or/Xor]OfferedMode"
+
+	eventsConsumedList := OrderedCollection new.
+	parametersUsedList := OrderedCollection new.
+	servicesUsedList := OrderedCollection new.
+
+	eventsProducedList := OrderedCollection new.
+	parametersProvidedList := OrderedCollection new.
+	servicesProvidedList := OrderedCollection new.
+
+	listImplementationBoth := OrderedCollection new
+]
+
+{ #category : #initialization }
+MolInterfaces >> enableBrowseButton: listOnScreen [
+	"determines which list was the last one selected, necessary for using the Browse button"
+
+	listOnScreen whenSelectionChangedDo: [
+		implementationList := listOnScreen.
+		listOnScreen selectedItem ifNotNil: [ buttonBrowse enable ] ]
+]
+
+{ #category : #'as yet unclassified' }
+MolInterfaces >> fillRequiredAndOfferedLists [
+	"used for the and mode"
+
+	requiredList items: listImplementationBoth.
+	offeredList items: listImplementationBoth
+]
+
+{ #category : #initialization }
+MolInterfaces >> initializePresenters [
+
+	"Required OR Offered selected by default in the drop down list"
+
+	super initializePresenters.
+
+		"set to a placeholder value since the name of the interface is given after in execute: in the contextual menu side of things (MolInspectInterfaceImplementationsCmdCommand)"
+	selectedInterface := ''.
+
+	eventsConsumedList := OrderedCollection new.
+	parametersUsedList := OrderedCollection new.
+	servicesUsedList := OrderedCollection new.
+
+	eventsProducedList := OrderedCollection new.
+	parametersProvidedList := OrderedCollection new.
+	servicesProvidedList := OrderedCollection new.
+
+	"drop list, no width property"
+	dropList := self newDropList
+		            help: 'Component Types which are using this interface:';
+		            addItemLabeled: 'Required OR Offered'
+		            do: [ self orMode ];
+		            addItemLabeled: 'Required AND Offered'
+		            do: [ self andMode ];
+		            addItemLabeled: 'Required XOR Offered'
+		            do: [ self xorMode ].
+
+	requiredList := SpFilteringListDoubleClickPresenter new.
+	requiredList
+		displayIcon: [ :elem | self iconNamed: elem systemIconName ];
+		contextMenu: [ self listMenu ].
+
+	offeredList := SpFilteringListDoubleClickPresenter new.
+	offeredList
+		displayIcon: [ :elem | self iconNamed: elem systemIconName ];
+		contextMenu: [ self listMenu ]
+]
+
+{ #category : #initialization }
+MolInterfaces >> interface: anInterface [
+	"when an interface is given, loads the filtering lists"
+
+	"only one interface can be selected at a time"
+
+	selectedInterface := anInterface.
+	self determineTypeInterface.
+	implemList := self listImplementations: anInterface.
+
+	self orMode
+]
+
+{ #category : #initialization }
+MolInterfaces >> interfaceListAssignment: interfaceList for: listOnScreen [
+	"adds the Types to a list if they are required or offered by the selected interface"
+
+	listOnScreen ifNotNil: [
+		interfaceList = OrderedCollection new ifFalse: [
+			listOnScreen items: interfaceList ] ]
+]
+
+{ #category : #initialization }
+MolInterfaces >> listMenu [
+
+	^ self newMenu addItem: [ :item |
+		  item
+			  name: 'See Component Implementations';
+			  icon: (self iconNamed: #package);
+			  help: 'Shows implementations of this Molecule Type';
+			  action: [ self seeComponentImplementations ] ]
+]
+
+{ #category : #initialization }
+MolInterfaces >> offeredList [
+	"used for test purposes"
+
+	^ offeredList
+]
+
+{ #category : #'as yet unclassified' }
+MolInterfaces >> orMode [
+	"if an implementation requires or provides the selected interface, make it appear in the correct column"
+
+	"is selected by default"
+
+	self emptyLists.
+
+	self addTypesInInterfaceLists.
+
+	self requireOrOffer.
+
+	self applyFilter
+]
+
+{ #category : #'as yet unclassified' }
+MolInterfaces >> require: listRequired andOffer: listOffered [
+		"adds the items in the lists shown on screen if the interface is both required and offered by an implementation"
+
+	listRequired do: [ :interfaceRequired |
+		listOffered do: [ :interfaceOffered |
+			interfaceRequired = interfaceOffered ifTrue: [
+				listImplementationBoth add: interfaceRequired ] ] ]
+]
+
+{ #category : #'as yet unclassified' }
+MolInterfaces >> require: listRequired xorOffer: listOffered [
+	"removes the items in the lists shown on screen if the interface is both required and offered by an implementation"
+
+	listRequired do: [ :interfaceRequired |
+		listOffered do: [ :interfaceOffered |
+			interfaceRequired = interfaceOffered ifTrue: [
+				listRequired remove: interfaceRequired.
+				listOffered remove: interfaceRequired ] ] ]
+]
+
+{ #category : #'as yet unclassified' }
+MolInterfaces >> requireOrOffer [
+	"adds the items in the lists shown on screen if the interface is required or offered by a Type"
+
+	self interfaceListAssignment: eventsConsumedList for: requiredList.
+	self interfaceListAssignment: parametersUsedList for: requiredList.
+	self interfaceListAssignment: servicesUsedList for: requiredList.
+
+	self interfaceListAssignment: eventsProducedList for: offeredList.
+	self interfaceListAssignment: parametersProvidedList for: offeredList.
+	self interfaceListAssignment: servicesProvidedList for: offeredList
+]
+
+{ #category : #initialization }
+MolInterfaces >> requiredList [
+	"used for test purposes"
+
+	^ requiredList
+]
+
+{ #category : #initialization }
+MolInterfaces >> seeComponentImplementations [
+	"code based on the execute method in MolInspectTypeImplementationsCmdCommand without the multiple selection part since multiple elements can't be chosen at the same time in requiredList and offeredList"
+
+	| selectedType implem |
+	selectedType := implementationList selectedItem.
+	implem := MolImplementations new.
+
+	selectedType isComponentType ifTrue: [
+		implem type: selectedType.
+		implem open ]
+]
+
+{ #category : #initialization }
+MolInterfaces >> title [
+
+	^ selectedInterface asString , ' ' , typeInterface asLowercase
+]
+
+{ #category : #'as yet unclassified' }
+MolInterfaces >> xorMode [
+	"boolean operator equivalent to OR minus AND, show a Type only if it exists and doesn't appear in both columns (requires or offers the interface, but not both)"
+
+	self emptyLists.
+
+	"adds the interfaces"
+	self addTypesInInterfaceLists.
+
+	"removes implementations that both require and offer this interface"
+	self require: eventsConsumedList xorOffer: eventsProducedList.
+	self require: servicesUsedList xorOffer: servicesProvidedList.
+	self require: parametersUsedList xorOffer: parametersProvidedList.
+
+	"adds the interfaces in requiredList and offeredList"
+	self requireOrOffer.
+
+	self applyFilter
+]

--- a/src/Molecule-IDE/MolOptions.class.st
+++ b/src/Molecule-IDE/MolOptions.class.st
@@ -1,0 +1,64 @@
+Class {
+	#name : #MolOptions,
+	#superclass : #SpPresenter,
+	#instVars : [
+		'implementationList',
+		'actionBar',
+		'buttonBrowse',
+		'buttonClose'
+	],
+	#category : #'Molecule-IDE-Tools'
+}
+
+{ #category : #tests }
+MolOptions >> buttonBrowse [
+	"used for test purposes"
+
+	^ buttonBrowse
+]
+
+{ #category : #tests }
+MolOptions >> buttonBrowseAction [ 
+]
+
+{ #category : #tests }
+MolOptions >> implementationList [
+	"used for test purposes"
+
+	^ implementationList
+]
+
+{ #category : #tests }
+MolOptions >> initializePresenters [
+	"buttons"
+
+	buttonBrowse := self newButton
+		                label: 'Browse';
+		                icon: (self iconNamed: #package);
+		                help: 'Browse the selected implementation';
+		                action: [ self buttonBrowseAction ];
+		                disable;
+		                yourself.
+
+	buttonClose := self newButton
+		               label: 'Close';
+		               icon: (self iconNamed: #smallCancel);
+		               help: 'Close the window';
+		               action: [ self delete ];
+		               yourself.
+		
+"action bar"
+	actionBar := self newActionBar
+		             addLast: buttonBrowse;
+		             addLast: buttonClose;
+		             yourself
+]
+
+{ #category : #tests }
+MolOptions >> listImplementations: selectedClass [
+	"necessary to use a Collection or one of its subclasses (Array in this case) to retrieve implementations of the selected Type Trait"
+
+	(selectedClass = '' or: selectedClass = OrderedCollection new)
+		ifFalse: [
+			^ selectedClass users asArray ]
+]

--- a/src/Molecule-IDE/MolTypeCmdCommand.class.st
+++ b/src/Molecule-IDE/MolTypeCmdCommand.class.st
@@ -1,0 +1,39 @@
+Class {
+	#name : #MolTypeCmdCommand,
+	#superclass : #MolCmdCommand,
+	#instVars : [
+		'typeName'
+	],
+	#category : #'Molecule-IDE-Tools'
+}
+
+{ #category : #testing }
+MolTypeCmdCommand class >> canBeExecutedInContext: aToolContext [
+
+	| list selectedItem selected |
+	(super canBeExecutedInContext: aToolContext) ifFalse: [ ^ false ].
+	aToolContext selectedItems ifEmpty: [ ^ false ].
+
+	selectedItem := aToolContext selectedItems at: 1.
+	selected := selectedItem browserItem actualObject name.
+
+	"find all Types"
+	list := SystemNavigation default allClasses select: [ :c |
+		        c isTrait and: [ c isComponentType ] ].
+
+	"return if selected object is in list of component"
+	^ list includes: (self class environment at: selected asSymbol)
+]
+
+{ #category : #'as yet unclassified' }
+MolTypeCmdCommand >> selectedClass [
+
+	^ selectedItems collect: [ :p | p browserItem actualObject ]
+]
+
+{ #category : #'as yet unclassified' }
+MolTypeCmdCommand >> selectedTypeClass [
+	"this method returns the class selected in the System Browser that is a Type"
+
+	^ self selectedClass select: [ :c | c isComponentType ]
+]

--- a/src/Molecule-IDE/MolUtils.extension.st
+++ b/src/Molecule-IDE/MolUtils.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #MolUtils }
+
+{ #category : #'*Molecule-IDE' }
+MolUtils class >> listTypesUsingInterfaces: anInterface [
+
+	self flag: 'to do'.
+	^ anInterface 
+]

--- a/src/Molecule-IDE/MolWorld.class.st
+++ b/src/Molecule-IDE/MolWorld.class.st
@@ -171,6 +171,13 @@ MolWorld class >> menu60ReportBugOn: aBuilder [
 		action: [WebBrowser openOn: 'https://github.com/OpenSmock/Molecule/issues/new']
 ]
 
+{ #category : #'instance creation' }
+MolWorld class >> newComponent [
+
+	<script>
+	MolNewComponentLibrary new open
+]
+
 { #category : #scripts }
 MolWorld class >> openDefineComponentDialog [
 
@@ -215,20 +222,37 @@ MolWorld class >> toolsMenu10DefineComponentOn: aBuilder [
 
 { #category : #'menu - tools' }
 MolWorld class >> toolsMenu110DeepCleanUp: aBuilder [
+
 	<worldMenu>
 	(aBuilder item: #MoleculeClearComponent)
 		parent: #MoleculeDebug;
 		order: 11.0;
 		icon: (self iconNamed: #stop);
-		action: [| result |
+		action: [
+			| result |
 			"Confirmation window"
-			result := UIManager default confirm: 'Do you want to scan and clean all the Molecule Components of your Pharo image ? 
-This action may be necessary if your system is broken.' 
-				label: 'Molecule - Confirmation'.
-			result ifTrue:[ MolComponentManager deepCleanUp]. 
-		];
+			result := UIManager default
+				          confirm:
+					          'Do you want to scan and clean all the Molecule Components of your Pharo image ? 
+This action may be necessary if your system is broken.'
+				          label: 'Molecule - Confirmation'.
+			result ifTrue: [ MolComponentManager deepCleanUp ] ];
 		label: 'Garbage, cleanup and release all components';
-		help: 'Cleanup all Molecule system instances and components of the image'
+		help:
+			'Cleanup all Molecule system instances and components of the image';
+				withSeparatorAfter
+]
+
+{ #category : #'menu - tools' }
+MolWorld class >> toolsMenu120DefineComponentOn: aBuilder [
+
+	<worldMenu>
+	(aBuilder item: #MoleculeNewComponent)
+		parent: #MoleculeDebug;
+		order: 12.0;
+		action: [ self newComponent ];
+		icon: (self iconNamed: #smallUpdate);
+		label: 'New Component'
 ]
 
 { #category : #'menu - tools' }

--- a/src/Molecule-IDE/SpFilteringListDoubleClickPresenter.class.st
+++ b/src/Molecule-IDE/SpFilteringListDoubleClickPresenter.class.st
@@ -1,0 +1,30 @@
+Class {
+	#name : #SpFilteringListDoubleClickPresenter,
+	#superclass : #SpFilteringListPresenter,
+	#category : #'Molecule-IDE-Tools'
+}
+
+{ #category : #simulation }
+SpFilteringListDoubleClickPresenter >> connectPresenters [
+
+	super connectPresenters.
+	self doubleClickActivated
+]
+
+{ #category : #simulation }
+SpFilteringListDoubleClickPresenter >> doubleClickActivated [
+	"activates the Browse functionality by double-clicking an element"
+
+	| item |
+	listPresenter whenActivatedDo: [
+		item := listPresenter selectedItem.
+		item browse ]
+]
+
+{ #category : #simulation }
+SpFilteringListDoubleClickPresenter >> initializePresenters [
+	"changes the original 'Filter...' placeholder text to 'Hit return to accept'"
+
+	super initializePresenters.
+	filterInputPresenter placeholder: 'Hit return to accept'
+]


### PR DESCRIPTION
- When selecting a Molecule Type Trait, the Extra submenu now comports a "See component implementations" option which is used to visualize the implementations of the selected Type
- When selecting a Molecule interface, the Extra submenu now comports a "See component users" option which is used to visualize which Type require and/or offer the selected interface (a drop-down list is used to change the boolean operator used between lists) 
Right-clicking a Type on the latter option shows the first option so that they can be chained together. 
Each element can be double-clicked to be browsed (opens a System Browser on the selected class). 
Each list can also be filtered.