### PR TITLE
Dev impl define contract

### DIFF
--- a/src/Molecule-Tests/MolCompleteComponentOverloadImpl.class.st
+++ b/src/Molecule-Tests/MolCompleteComponentOverloadImpl.class.st
@@ -1,3 +1,6 @@
+"
+I am a component impl overloading my contract for impl purpose
+"
 Class {
 	#name : #MolCompleteComponentOverloadImpl,
 	#superclass : #MolAbstractComponentImpl,

--- a/src/Molecule-Tests/MolCompleteComponentOverloadImpl.class.st
+++ b/src/Molecule-Tests/MolCompleteComponentOverloadImpl.class.st
@@ -1,0 +1,148 @@
+Class {
+	#name : #MolCompleteComponentOverloadImpl,
+	#superclass : #MolAbstractComponentImpl,
+	#traits : 'MolCompleteComponent + MolUsedServices + MolUsedEvents + MolUsedParameters + MolUsedParameters2 + MolUsedServices2 + MolUsedEvents2',
+	#classTraits : 'MolCompleteComponent classTrait + MolUsedServices classTrait + MolUsedEvents classTrait + MolUsedParameters classTrait + MolUsedParameters2 classTrait + MolUsedServices2 classTrait + MolUsedEvents2 classTrait',
+	#category : #'Molecule-Tests-Resources - Components'
+}
+
+{ #category : #'accessing - events' }
+MolCompleteComponentOverloadImpl class >> consumedComponentEvents [
+
+	<componentContract>
+	^ { MolUsedEvents. MolUsedEvents2 }
+]
+
+{ #category : #'accessing - events' }
+MolCompleteComponentOverloadImpl class >> producedComponentEvents [
+
+	<componentContract> 
+	^ {
+		  MolUsedEvents.
+		  MolUsedEvents2 }
+]
+
+{ #category : #'accessing - parameters' }
+MolCompleteComponentOverloadImpl class >> providedComponentParameters [
+
+	<componentContract>
+	^ { MolUsedParameters. MolUsedParameters2. }
+]
+
+{ #category : #'accessing - services' }
+MolCompleteComponentOverloadImpl class >> providedComponentServices [
+
+	<componentContract>
+	^ { MolUsedServices. MolUsedServices2 }
+]
+
+{ #category : #'accessing - parameters' }
+MolCompleteComponentOverloadImpl class >> usedComponentParameters [
+
+	<componentContract>
+	^ { MolUsedParameters. MolUsedParameters2 }
+]
+
+{ #category : #'accessing - services' }
+MolCompleteComponentOverloadImpl class >> usedComponentServices [
+
+	<componentContract>
+	^ { MolUsedServices. MolUsedServices2 }
+]
+
+{ #category : #events }
+MolCompleteComponentOverloadImpl >> event [
+	^ #event
+]
+
+{ #category : #'component accessing' }
+MolCompleteComponentOverloadImpl >> getMolUsedEvents2Notifier [
+	^self eventsNotifiers at: MolUsedEvents2 ifAbsent: [^MolNotFoundEventsNotifier new interface: MolUsedEvents2 name: nil].
+]
+
+{ #category : #'component accessing' }
+MolCompleteComponentOverloadImpl >> getMolUsedEvents2Subscriber [
+	| eventsSymbol eventsSubscriber itf |
+	itf := MolUsedEvents2.
+	eventsSymbol := self eventsSubscribers at: itf ifAbsent: [^MolNotFoundEventsSubscriber new interface: itf name: nil].
+	eventsSymbol isCollection
+	 	ifTrue: 
+			[eventsSubscriber := MolComponentManager default locatorServices 
+						searchEventsSubscriberFor: MolUsedEvents2 named: eventsSymbol ]. 
+	^eventsSubscriber
+]
+
+{ #category : #'component accessing' }
+MolCompleteComponentOverloadImpl >> getMolUsedEventsNotifier [
+	^self eventsNotifiers at: MolUsedEvents ifAbsent: [^MolNotFoundEventsNotifier new interface: MolUsedEvents name: nil].
+]
+
+{ #category : #'component accessing' }
+MolCompleteComponentOverloadImpl >> getMolUsedEventsSubscriber [
+	| eventsSymbol eventsSubscriber itf |
+	itf := MolUsedEvents.
+	eventsSymbol := self eventsSubscribers at: itf ifAbsent: [^MolNotFoundEventsSubscriber new interface: itf name: nil].
+	eventsSymbol isCollection
+	 	ifTrue: 
+			[eventsSubscriber := MolComponentManager default locatorServices 
+						searchEventsSubscriberFor: MolUsedEvents named: eventsSymbol ]. 
+	^eventsSubscriber
+]
+
+{ #category : #'component accessing' }
+MolCompleteComponentOverloadImpl >> getMolUsedParameters2Provider [
+	| parametersSymbol parametersProvider itf |
+
+	itf := MolUsedParameters2.
+	parametersSymbol := self parametersProviders at: itf ifAbsent: [nil].
+	(parametersSymbol isNil or:[parametersSymbol isSymbol not]) ifTrue: [ ^ MolNotFoundParametersProvider new interface: itf name: nil ].
+
+	parametersProvider := MolComponentManager default locatorServices searchParametersProviderFor: MolUsedParameters2 named: parametersSymbol.
+	^parametersProvider
+]
+
+{ #category : #'component accessing' }
+MolCompleteComponentOverloadImpl >> getMolUsedParametersProvider [
+	| parametersSymbol parametersProvider itf |
+
+	itf := MolUsedParameters.
+	parametersSymbol := self parametersProviders at: itf ifAbsent: [nil].
+	(parametersSymbol isNil or:[parametersSymbol isSymbol not]) ifTrue: [ ^ MolNotFoundParametersProvider new interface: itf name: nil ].
+
+	parametersProvider := MolComponentManager default locatorServices searchParametersProviderFor: MolUsedParameters named: parametersSymbol.
+	^parametersProvider
+]
+
+{ #category : #'component accessing' }
+MolCompleteComponentOverloadImpl >> getMolUsedServices2Provider [
+	| servicesSymbol servicesProvider itf |
+
+	itf := MolUsedServices2.
+	servicesSymbol := self servicesProviders at: itf ifAbsent: [nil].
+	(servicesSymbol isNil or:[servicesSymbol isSymbol not]) ifTrue: [ ^ MolNotFoundServicesProvider new interface: itf name: nil ].
+
+	servicesProvider := MolComponentManager default locatorServices searchServicesProviderFor: MolUsedServices2 named: servicesSymbol.
+	^servicesProvider
+]
+
+{ #category : #'component accessing' }
+MolCompleteComponentOverloadImpl >> getMolUsedServicesProvider [
+	| servicesSymbol servicesProvider itf |
+
+	itf := MolUsedServices.
+	servicesSymbol := self servicesProviders at: itf ifAbsent: [nil].
+	(servicesSymbol isNil or:[servicesSymbol isSymbol not]) ifTrue: [ ^ MolNotFoundServicesProvider new interface: itf name: nil ].
+
+	servicesProvider := MolComponentManager default locatorServices searchServicesProviderFor: MolUsedServices named: servicesSymbol.
+	^servicesProvider
+]
+
+{ #category : #parameters }
+MolCompleteComponentOverloadImpl >> parameter [
+	^ #parameter
+]
+
+{ #category : #service }
+MolCompleteComponentOverloadImpl >> service [
+	^ #service
+]

--- a/src/Molecule-Tests/MolComponentFactoryTest.class.st
+++ b/src/Molecule-Tests/MolComponentFactoryTest.class.st
@@ -265,6 +265,21 @@ MolComponentFactoryTest >> testComponentContractChanged [
 ]
 
 { #category : #tests }
+MolComponentFactoryTest >> testComponentContractImplGeneration [
+
+	| toFind |
+	MolCompleteComponentOverloadImpl defineComponent.
+	toFind := { #getMolUsedEventsNotifier. #getMolUsedParametersProvider.
+	          #getMolUsedServicesProvider. #getMolUsedEventsSubscriber.
+	          #getMolUsedEventsSubscriber. #getMolUsedEvents2Notifier.
+	          #getMolUsedParameters2Provider.
+	          #getMolUsedServices2Provider }.
+	toFind := toFind reject: [ :e |
+		          MolCompleteComponentOverloadImpl allSelectors includes: e ].
+	self assert: toFind isEmpty
+]
+
+{ #category : #tests }
 MolComponentFactoryTest >> testComponentFactoryDefaultClass [
 	MolComponentFactory cleanUp.
 

--- a/src/Molecule-Tests/MolUsedEvents2.trait.st
+++ b/src/Molecule-Tests/MolUsedEvents2.trait.st
@@ -1,0 +1,12 @@
+Trait {
+	#name : #MolUsedEvents2,
+	#traits : 'MolComponentEvents',
+	#classTraits : 'MolComponentEvents classTrait',
+	#category : #'Molecule-Tests-Resources - Contracts'
+}
+
+{ #category : #events }
+MolUsedEvents2 >> event2 [
+
+	^ #event2
+]

--- a/src/Molecule-Tests/MolUsedEvents2.trait.st
+++ b/src/Molecule-Tests/MolUsedEvents2.trait.st
@@ -1,3 +1,6 @@
+"
+I am a event trait used for impl overloading test
+"
 Trait {
 	#name : #MolUsedEvents2,
 	#traits : 'MolComponentEvents',

--- a/src/Molecule-Tests/MolUsedParameters2.trait.st
+++ b/src/Molecule-Tests/MolUsedParameters2.trait.st
@@ -1,3 +1,6 @@
+"
+I am a param trait used for impl overloading test
+"
 Trait {
 	#name : #MolUsedParameters2,
 	#traits : 'MolComponentParameters',

--- a/src/Molecule-Tests/MolUsedParameters2.trait.st
+++ b/src/Molecule-Tests/MolUsedParameters2.trait.st
@@ -1,0 +1,12 @@
+Trait {
+	#name : #MolUsedParameters2,
+	#traits : 'MolComponentParameters',
+	#classTraits : 'MolComponentParameters classTrait',
+	#category : #'Molecule-Tests-Resources - Contracts'
+}
+
+{ #category : #'parameters 2' }
+MolUsedParameters2 >> parameter2 [
+
+	^ #parameter2
+]

--- a/src/Molecule-Tests/MolUsedServices2.trait.st
+++ b/src/Molecule-Tests/MolUsedServices2.trait.st
@@ -1,3 +1,6 @@
+"
+I am a services trait used for impl overloading test
+"
 Trait {
 	#name : #MolUsedServices2,
 	#traits : 'MolComponentServices',

--- a/src/Molecule-Tests/MolUsedServices2.trait.st
+++ b/src/Molecule-Tests/MolUsedServices2.trait.st
@@ -1,0 +1,12 @@
+Trait {
+	#name : #MolUsedServices2,
+	#traits : 'MolComponentServices',
+	#classTraits : 'MolComponentServices classTrait',
+	#category : #'Molecule-Tests-Resources - Contracts'
+}
+
+{ #category : #'service 2' }
+MolUsedServices2 >> service2 [
+
+	^ #service2
+]

--- a/src/Molecule-Tests/MolUtilsTest.class.st
+++ b/src/Molecule-Tests/MolUtilsTest.class.st
@@ -91,17 +91,41 @@ MolUtilsTest >> testConsumedComponentEvents [
 	self assert: (MolUtils consumedComponentEvents: nil) isEmpty.
 	self assert: (MolUtils consumedComponentEvents: 45) isEmpty.
 	self assert: (MolUtils consumedComponentEvents: Integer) isEmpty.
-	self assert: (MolUtils consumedComponentEvents: MolComponentImpl) isEmpty.
-	self assert: (MolUtils consumedComponentEvents: MolCompleteComponentImpl) notEmpty.
-	self assert: ((MolUtils consumedComponentEvents: MolCompleteComponentImpl) first) equals: MolUsedEvents.
-	self assert: (MolUtils consumedComponentEvents: MolCompleteComponentImpl new) notEmpty.
-	self assert: ((MolUtils consumedComponentEvents: MolCompleteComponentImpl new) first) equals: MolUsedEvents.
-	self assert: (MolUtils consumedComponentEvents: MolCompleteComponent) notEmpty.
-	self assert: ((MolUtils consumedComponentEvents: MolCompleteComponent) first) equals: MolUsedEvents.
-	
-	self assert: (MolUtils consumedComponentEvents: MolComponentServices) isEmpty.
-	self assert: (MolUtils consumedComponentEvents: MolComponentParameters) isEmpty.
-	self assert: (MolUtils consumedComponentEvents: MolComponentEvents) isEmpty.
+	self assert:
+		(MolUtils consumedComponentEvents: MolComponentImpl) isEmpty.
+	self assert:
+		(MolUtils consumedComponentEvents: MolCompleteComponentImpl)
+			notEmpty.
+	self
+		assert:
+			(MolUtils consumedComponentEvents: MolCompleteComponentOverloadImpl)
+				size
+		equals: 2.		
+	self
+		assert:
+		(MolUtils consumedComponentEvents: MolCompleteComponentImpl) first
+		equals: MolUsedEvents.
+	self assert:
+		(MolUtils consumedComponentEvents: MolCompleteComponentImpl new)
+			notEmpty.
+	self
+		assert:
+		(MolUtils consumedComponentEvents: MolCompleteComponentImpl new)
+			first
+		equals: MolUsedEvents.
+	self assert:
+		(MolUtils consumedComponentEvents: MolCompleteComponent) notEmpty.
+	self
+		assert:
+		(MolUtils consumedComponentEvents: MolCompleteComponent) first
+		equals: MolUsedEvents.
+
+	self assert:
+		(MolUtils consumedComponentEvents: MolComponentServices) isEmpty.
+	self assert:
+		(MolUtils consumedComponentEvents: MolComponentParameters) isEmpty.
+	self assert:
+		(MolUtils consumedComponentEvents: MolComponentEvents) isEmpty
 ]
 
 { #category : #tests }
@@ -314,17 +338,40 @@ MolUtilsTest >> testProducedComponentEvents [
 	self assert: (MolUtils producedComponentEvents: nil) isEmpty.
 	self assert: (MolUtils producedComponentEvents: 45) isEmpty.
 	self assert: (MolUtils producedComponentEvents: Integer) isEmpty.
-	self assert: (MolUtils producedComponentEvents: MolComponentImpl) isEmpty.
-	self assert: (MolUtils producedComponentEvents: MolCompleteComponentImpl) notEmpty.
-	self assert: ((MolUtils producedComponentEvents: MolCompleteComponentImpl) first) equals: MolUsedEvents.
-	self assert: (MolUtils producedComponentEvents: MolCompleteComponentImpl new) notEmpty.
-	self assert: ((MolUtils producedComponentEvents: MolCompleteComponentImpl new) first) equals: MolUsedEvents.
-	self assert: (MolUtils producedComponentEvents: MolCompleteComponent) notEmpty.
-	self assert: ((MolUtils producedComponentEvents: MolCompleteComponent) first) equals: MolUsedEvents.
-	
-	self assert: (MolUtils producedComponentEvents: MolComponentServices) isEmpty.
-	self assert: (MolUtils producedComponentEvents: MolComponentParameters) isEmpty.
-	self assert: (MolUtils producedComponentEvents: MolComponentEvents) isEmpty.
+	self assert:
+		(MolUtils producedComponentEvents: MolComponentImpl) isEmpty.
+	self assert:
+		(MolUtils producedComponentEvents: MolCompleteComponentImpl)
+			notEmpty.
+	self
+		assert: (MolUtils producedComponentEvents:
+				 MolCompleteComponentOverloadImpl) size
+		equals: 2.
+	self
+		assert:
+		(MolUtils producedComponentEvents: MolCompleteComponentImpl) first
+		equals: MolUsedEvents.
+	self assert:
+		(MolUtils producedComponentEvents: MolCompleteComponentImpl new)
+			notEmpty.
+	self
+		assert:
+		(MolUtils producedComponentEvents: MolCompleteComponentImpl new)
+			first
+		equals: MolUsedEvents.
+	self assert:
+		(MolUtils producedComponentEvents: MolCompleteComponent) notEmpty.
+	self
+		assert:
+		(MolUtils producedComponentEvents: MolCompleteComponent) first
+		equals: MolUsedEvents.
+
+	self assert:
+		(MolUtils producedComponentEvents: MolComponentServices) isEmpty.
+	self assert:
+		(MolUtils producedComponentEvents: MolComponentParameters) isEmpty.
+	self assert:
+		(MolUtils producedComponentEvents: MolComponentEvents) isEmpty
 ]
 
 { #category : #tests }
@@ -333,17 +380,44 @@ MolUtilsTest >> testProvidedComponentParameters [
 	self assert: (MolUtils providedComponentParameters: nil) isEmpty.
 	self assert: (MolUtils providedComponentParameters: 45) isEmpty.
 	self assert: (MolUtils providedComponentParameters: Integer) isEmpty.
-	self assert: (MolUtils providedComponentParameters: MolComponentImpl) isEmpty.
-	self assert: (MolUtils providedComponentParameters: MolCompleteComponentImpl) notEmpty.
-	self assert: ((MolUtils providedComponentParameters: MolCompleteComponentImpl) first) equals: MolUsedParameters.
-	self assert: (MolUtils providedComponentParameters: MolCompleteComponentImpl new) notEmpty.
-	self assert: ((MolUtils providedComponentParameters: MolCompleteComponentImpl new) first) equals: MolUsedParameters.
-	self assert: (MolUtils providedComponentParameters: MolCompleteComponent) notEmpty.
-	self assert: ((MolUtils providedComponentParameters: MolCompleteComponent) first) equals: MolUsedParameters.
-	
-	self assert: (MolUtils providedComponentParameters: MolComponentServices) isEmpty.
-	self assert: (MolUtils providedComponentParameters: MolComponentParameters) isEmpty.
-	self assert: (MolUtils providedComponentParameters: MolComponentEvents) isEmpty.
+	self assert:
+		(MolUtils providedComponentParameters: MolComponentImpl) isEmpty.
+	self assert:
+		(MolUtils providedComponentParameters: MolCompleteComponentImpl)
+			notEmpty.
+	self
+		assert:
+			(MolUtils providedComponentParameters:
+				 MolCompleteComponentOverloadImpl) size
+		equals: 2.
+	self
+		assert:
+		(MolUtils providedComponentParameters: MolCompleteComponentImpl)
+			first
+		equals: MolUsedParameters.
+	self assert:
+		(MolUtils providedComponentParameters: MolCompleteComponentImpl new)
+			notEmpty.
+	self
+		assert:
+			(MolUtils providedComponentParameters: MolCompleteComponentImpl new)
+				first
+		equals: MolUsedParameters.
+	self assert:
+		(MolUtils providedComponentParameters: MolCompleteComponent)
+			notEmpty.
+	self
+		assert:
+		(MolUtils providedComponentParameters: MolCompleteComponent) first
+		equals: MolUsedParameters.
+
+	self assert:
+		(MolUtils providedComponentParameters: MolComponentServices) isEmpty.
+	self assert:
+		(MolUtils providedComponentParameters: MolComponentParameters)
+			isEmpty.
+	self assert:
+		(MolUtils providedComponentParameters: MolComponentEvents) isEmpty
 ]
 
 { #category : #tests }
@@ -352,17 +426,41 @@ MolUtilsTest >> testProvidedComponentServices [
 	self assert: (MolUtils providedComponentServices: nil) isEmpty.
 	self assert: (MolUtils providedComponentServices: 45) isEmpty.
 	self assert: (MolUtils providedComponentServices: Integer) isEmpty.
-	self assert: (MolUtils providedComponentServices: MolComponentImpl) isEmpty.
-	self assert: (MolUtils providedComponentServices: MolCompleteComponentImpl) notEmpty.
-	self assert: ((MolUtils providedComponentServices: MolCompleteComponentImpl) first) equals: MolUsedServices.
-	self assert: (MolUtils providedComponentServices: MolCompleteComponentImpl new) notEmpty.
-	self assert: ((MolUtils providedComponentServices: MolCompleteComponentImpl new) first) equals: MolUsedServices.
-	self assert: (MolUtils providedComponentServices: MolCompleteComponent) notEmpty.
-	self assert: ((MolUtils providedComponentServices: MolCompleteComponent) first) equals: MolUsedServices.
-	
-	self assert: (MolUtils providedComponentServices: MolComponentServices) isEmpty.
-	self assert: (MolUtils providedComponentServices: MolComponentParameters) isEmpty.
-	self assert: (MolUtils providedComponentServices: MolComponentEvents) isEmpty.
+	self assert:
+		(MolUtils providedComponentServices: MolComponentImpl) isEmpty.
+	self assert:
+		(MolUtils providedComponentServices: MolCompleteComponentImpl)
+			notEmpty.
+	self
+		assert:
+			(MolUtils providedComponentServices:
+				 MolCompleteComponentOverloadImpl) size
+		equals: 2.
+	self
+		assert:
+		(MolUtils providedComponentServices: MolCompleteComponentImpl) first
+		equals: MolUsedServices.
+	self assert:
+		(MolUtils providedComponentServices: MolCompleteComponentImpl new)
+			notEmpty.
+	self
+		assert:
+			(MolUtils providedComponentServices: MolCompleteComponentImpl new)
+				first
+		equals: MolUsedServices.
+	self assert:
+		(MolUtils providedComponentServices: MolCompleteComponent) notEmpty.
+	self
+		assert:
+		(MolUtils providedComponentServices: MolCompleteComponent) first
+		equals: MolUsedServices.
+
+	self assert:
+		(MolUtils providedComponentServices: MolComponentServices) isEmpty.
+	self assert:
+		(MolUtils providedComponentServices: MolComponentParameters) isEmpty.
+	self assert:
+		(MolUtils providedComponentServices: MolComponentEvents) isEmpty
 ]
 
 { #category : #tests }
@@ -633,17 +731,40 @@ MolUtilsTest >> testUsedComponentParameters [
 	self assert: (MolUtils usedComponentParameters: nil) isEmpty.
 	self assert: (MolUtils usedComponentParameters: 45) isEmpty.
 	self assert: (MolUtils usedComponentParameters: Integer) isEmpty.
-	self assert: (MolUtils usedComponentParameters: MolComponentImpl) isEmpty.
-	self assert: (MolUtils usedComponentParameters: MolCompleteComponentImpl) notEmpty.
-	self assert: ((MolUtils usedComponentParameters: MolCompleteComponentImpl) first) equals: MolUsedParameters.
-	self assert: (MolUtils usedComponentParameters: MolCompleteComponentImpl new) notEmpty.
-	self assert: ((MolUtils usedComponentParameters: MolCompleteComponentImpl new) first) equals: MolUsedParameters.
-	self assert: (MolUtils usedComponentParameters: MolCompleteComponent) notEmpty.
-	self assert: ((MolUtils usedComponentParameters: MolCompleteComponent) first) equals: MolUsedParameters.
-	
-	self assert: (MolUtils usedComponentParameters: MolComponentServices) isEmpty.
-	self assert: (MolUtils usedComponentParameters: MolComponentParameters) isEmpty.
-	self assert: (MolUtils usedComponentParameters: MolComponentEvents) isEmpty.
+	self assert:
+		(MolUtils usedComponentParameters: MolComponentImpl) isEmpty.
+	self assert:
+		(MolUtils usedComponentParameters: MolCompleteComponentImpl)
+			notEmpty.
+	self
+		assert: (MolUtils usedComponentParameters:
+				 MolCompleteComponentOverloadImpl) size
+		equals: 2.
+	self
+		assert:
+		(MolUtils usedComponentParameters: MolCompleteComponentImpl) first
+		equals: MolUsedParameters.
+	self assert:
+		(MolUtils usedComponentParameters: MolCompleteComponentImpl new)
+			notEmpty.
+	self
+		assert:
+		(MolUtils usedComponentParameters: MolCompleteComponentImpl new)
+			first
+		equals: MolUsedParameters.
+	self assert:
+		(MolUtils usedComponentParameters: MolCompleteComponent) notEmpty.
+	self
+		assert:
+		(MolUtils usedComponentParameters: MolCompleteComponent) first
+		equals: MolUsedParameters.
+
+	self assert:
+		(MolUtils usedComponentParameters: MolComponentServices) isEmpty.
+	self assert:
+		(MolUtils usedComponentParameters: MolComponentParameters) isEmpty.
+	self assert:
+		(MolUtils usedComponentParameters: MolComponentEvents) isEmpty
 ]
 
 { #category : #tests }
@@ -652,15 +773,36 @@ MolUtilsTest >> testUsedComponentServices [
 	self assert: (MolUtils usedComponentServices: nil) isEmpty.
 	self assert: (MolUtils usedComponentServices: 45) isEmpty.
 	self assert: (MolUtils usedComponentServices: Integer) isEmpty.
-	self assert: (MolUtils usedComponentServices: MolComponentImpl) isEmpty.
-	self assert: (MolUtils usedComponentServices: MolCompleteComponentImpl) notEmpty.
-	self assert: ((MolUtils usedComponentServices: MolCompleteComponentImpl) first) equals: MolUsedServices.
-	self assert: (MolUtils usedComponentServices: MolCompleteComponentImpl new) notEmpty.
-	self assert: ((MolUtils usedComponentServices: MolCompleteComponentImpl new) first) equals: MolUsedServices.
-	self assert: (MolUtils usedComponentServices: MolCompleteComponent) notEmpty.
-	self assert: ((MolUtils usedComponentServices: MolCompleteComponent) first) equals: MolUsedServices.
-	
-	self assert: (MolUtils usedComponentServices: MolComponentServices) isEmpty.
-	self assert: (MolUtils usedComponentServices: MolComponentParameters) isEmpty.
-	self assert: (MolUtils usedComponentServices: MolComponentEvents) isEmpty.
+	self assert:
+		(MolUtils usedComponentServices: MolComponentImpl) isEmpty.
+	self assert:
+		(MolUtils usedComponentServices: MolCompleteComponentImpl) notEmpty.
+	self
+		assert:
+			(MolUtils usedComponentServices: MolCompleteComponentOverloadImpl)
+				size
+		equals: 2.
+	self
+		assert:
+		(MolUtils usedComponentServices: MolCompleteComponentImpl) first
+		equals: MolUsedServices.
+	self assert:
+		(MolUtils usedComponentServices: MolCompleteComponentImpl new)
+			notEmpty.
+	self
+		assert:
+		(MolUtils usedComponentServices: MolCompleteComponentImpl new) first
+		equals: MolUsedServices.
+	self assert:
+		(MolUtils usedComponentServices: MolCompleteComponent) notEmpty.
+	self
+		assert: (MolUtils usedComponentServices: MolCompleteComponent) first
+		equals: MolUsedServices.
+
+	self assert:
+		(MolUtils usedComponentServices: MolComponentServices) isEmpty.
+	self assert:
+		(MolUtils usedComponentServices: MolComponentParameters) isEmpty.
+	self assert:
+		(MolUtils usedComponentServices: MolComponentEvents) isEmpty
 ]

--- a/src/Molecule/MolComponentFactory.class.st
+++ b/src/Molecule/MolComponentFactory.class.st
@@ -464,18 +464,23 @@ MolComponentFactory >> componentChangedAnnouncement: anAnnouncement [
 ]
 
 { #category : #announcements }
-MolComponentFactory >> contractChanged: aComponentType [
-	
-	aComponentType ifNil: [ ^ self error: '[Molecule] Error on contract changed notification.' ].
-	aComponentType isTrait ifFalse:[ ^ self ].
-	aComponentType isObsolete ifTrue:[ ^ self ].
-	aComponentType isComponentType ifFalse:[ ^ self ].
-	
-	self isDynamicContractUpdateActivated ifTrue: [ 
-		self defineComponentTypeImplementors: aComponentType
-	] ifFalse: [ 
-		dirtyComponentTypes add: aComponentType 
-	]
+MolComponentFactory >> contractChanged: aComponentOrType [
+
+	| class |
+	(MolUtils isComponentOrComponentClass: aComponentOrType) ifTrue: [
+		self isDynamicContractUpdateActivated ifTrue: [
+			class := aComponentOrType isClass ifTrue:[ aComponentOrType ] ifFalse:[ aComponentOrType class ].
+			self defineComponent: class ] ].
+	aComponentOrType ifNil: [
+		^ self error: '[Molecule] Error on contract changed notification.' ].
+
+	aComponentOrType isTrait ifFalse: [ ^ self ].
+	aComponentOrType isObsolete ifTrue: [ ^ self ].
+	aComponentOrType isComponentType ifFalse: [ ^ self ].
+
+	self isDynamicContractUpdateActivated
+		ifTrue: [ self defineComponentTypeImplementors: aComponentOrType ]
+		ifFalse: [ dirtyComponentTypes add: aComponentOrType ]
 ]
 
 { #category : #announcements }
@@ -611,28 +616,39 @@ MolComponentFactory >> generateComponentAccessorsFor: aSymbol withList: aCollect
 { #category : #'code generation' }
 MolComponentFactory >> generateOrRemoveConsumedEventsComponentAccessorsFor: aComponent [
 
+	| toDefine |
 	self removeOldConsumedEventsComponentAccessorsFor: aComponent.
-	
-	(aComponent haveComponentType and:[aComponent haveOwnComponentType]) ifFalse: [ ^ self ].
-	
-	self 
-		generateComponentAccessorsFor: #consumedEvents 
-		withList: aComponent componentType consumedComponentEvents 
-		in: aComponent 
+
+	(aComponent haveComponentType and: [ aComponent haveOwnComponentType ])
+		ifFalse: [ ^ self ].
+
+	toDefine := Set new.
+	toDefine addAll: aComponent componentType consumedComponentEvents.
+	toDefine addAll: aComponent consumedComponentEvents.
+
+	self
+		generateComponentAccessorsFor: #consumedEvents
+		withList: toDefine
+		in: aComponent
 		suffix: 'Subscriber'
-	
 ]
 
 { #category : #'code generation' }
 MolComponentFactory >> generateOrRemoveProducedEventsComponentAccessorsFor: aComponent [
 
+	| toDefine |
 	self removeOldProducedEventsComponentAccessorsFor: aComponent.
-	
-	(aComponent haveComponentType and: [ aComponent haveOwnComponentType ]) ifFalse: [ ^ self ].
+
+	(aComponent haveComponentType and: [ aComponent haveOwnComponentType ])
+		ifFalse: [ ^ self ].
+
+	toDefine := Set new.
+	toDefine addAll: aComponent componentType producedComponentEvents.
+	toDefine addAll: aComponent producedComponentEvents.
 
 	self
 		generateComponentAccessorsFor: #producedEvents
-		withList: aComponent componentType producedComponentEvents
+		withList: toDefine
 		in: aComponent
 		suffix: 'Notifier'
 ]
@@ -640,29 +656,42 @@ MolComponentFactory >> generateOrRemoveProducedEventsComponentAccessorsFor: aCom
 { #category : #'code generation' }
 MolComponentFactory >> generateOrRemoveUsedParametersComponentAccessorsFor: aComponent [
 
-	self removeOldUsedParametersAndServicesComponentAccessorsFor: aComponent.
-	
-	(aComponent haveComponentType and:[aComponent haveOwnComponentType]) ifFalse: [ ^ self ].
-	
-	self 
-		generateComponentAccessorsFor: #usedParameters 
-		withList: aComponent componentType usedComponentParameters 
-		in: aComponent 
+	| toDefine |
+	self removeOldUsedParametersAndServicesComponentAccessorsFor:
+		aComponent.
+
+	(aComponent haveComponentType and: [ aComponent haveOwnComponentType ])
+		ifFalse: [ ^ self ].
+
+	toDefine := Set new.
+	toDefine addAll: aComponent componentType usedComponentParameters.
+	toDefine addAll: aComponent usedComponentParameters.
+
+	self
+		generateComponentAccessorsFor: #usedParameters
+		withList: toDefine
+		in: aComponent
 		suffix: 'Provider'
-	
 ]
 
 { #category : #'code generation' }
 MolComponentFactory >> generateOrRemoveUsedServicesComponentAccessorsFor: aComponent [
- 
-	self removeOldUsedParametersAndServicesComponentAccessorsFor: aComponent.
-	
-	(aComponent haveComponentType and:[aComponent haveOwnComponentType]) ifFalse: [ ^ self ].
-	
-	self 
-		generateComponentAccessorsFor: #usedServices 
-		withList: aComponent componentType usedComponentServices 
-		in: aComponent 
+
+	| toDefine |
+	self removeOldUsedParametersAndServicesComponentAccessorsFor:
+		aComponent.
+
+	(aComponent haveComponentType and: [ aComponent haveOwnComponentType ])
+		ifFalse: [ ^ self ].
+
+	toDefine := Set new.
+	toDefine addAll: aComponent componentType usedComponentServices.
+	toDefine addAll: aComponent usedComponentServices.
+
+	self
+		generateComponentAccessorsFor: #usedServices
+		withList: toDefine
+		in: aComponent
 		suffix: 'Provider'
 ]
 
@@ -889,51 +918,71 @@ MolComponentFactory >> releaseSystemAnnouncements [
 
 { #category : #'code generation' }
 MolComponentFactory >> removeOldConsumedEventsComponentAccessorsFor: aComponent [
- 	"remove old consumed events but not the existing"
-	| toBeRemoveConsumedSelectors |
-	toBeRemoveConsumedSelectors := (aComponent selectors select:[ :s |  'get*Subscriber' match: (s asString)]) asOrderedCollection.
-	
+	"remove old consumed events but not the existing"
+
+	| toBeRemoveConsumedSelectors toPreserve |
+	toBeRemoveConsumedSelectors := (aComponent selectors select: [ :s |
+		                                'get*Subscriber' match: s asString ])
+		                               asOrderedCollection.
+
 	"check if the selectors are already in the current consumed events, in case don't remove them"
-	aComponent haveComponentType ifTrue:[
-		aComponent componentType consumedComponentEvents do:[ :e | 
-			toBeRemoveConsumedSelectors copy do:[ :sel | ('get', e printString, 'Subscriber' = sel) ifTrue:[toBeRemoveConsumedSelectors remove: sel]].
-		].
-	].
-	
-	toBeRemoveConsumedSelectors do:[ :s | aComponent removeSelector: s].
+	aComponent haveComponentType ifTrue: [
+		toPreserve := Set new.
+		toPreserve addAll: aComponent componentType consumedComponentEvents.
+		toPreserve addAll: aComponent consumedComponentEvents.
+		
+		toPreserve do: [ :e |
+			toBeRemoveConsumedSelectors copy do: [ :sel |
+				'get' , e printString , 'Subscriber' = sel ifTrue: [
+					toBeRemoveConsumedSelectors remove: sel ] ] ] ].
+
+	toBeRemoveConsumedSelectors do: [ :s | aComponent removeSelector: s ]
 ]
 
 { #category : #'code generation' }
 MolComponentFactory >> removeOldProducedEventsComponentAccessorsFor: aComponent [
- 	"remove old produced events but not the existing"
-	| toBeRemoveProducedSelectors |
-	toBeRemoveProducedSelectors := (aComponent selectors select:[ :s |  'get*Notifier' match: (s asString)]) asOrderedCollection.
-	
+	"remove old produced events but not the existing"
+
+	| toBeRemoveProducedSelectors toPreserve |
+	toBeRemoveProducedSelectors := (aComponent selectors select: [ :s |
+		                                'get*Notifier' match: s asString ])
+		                               asOrderedCollection.
+
 	"check if the selectors are already in the current produced events, in case don't remove them"
-	aComponent haveComponentType ifTrue:[
-		aComponent componentType producedComponentEvents do:[ :e | 
-			toBeRemoveProducedSelectors copy do:[ :sel | ('get', e printString, 'Notifier' = sel) ifTrue:[toBeRemoveProducedSelectors remove: sel]].
-		].
-	].
-	
-	toBeRemoveProducedSelectors do:[ :s | aComponent removeSelector: s].
+	aComponent haveComponentType ifTrue: [
+		toPreserve := Set new.
+		toPreserve addAll: aComponent componentType producedComponentEvents.
+		toPreserve addAll: aComponent producedComponentEvents.
+		
+		toPreserve do: [ :e |
+			toBeRemoveProducedSelectors copy do: [ :sel |
+				'get' , e printString , 'Notifier' = sel ifTrue: [
+					toBeRemoveProducedSelectors remove: sel ] ] ] ].
+
+	toBeRemoveProducedSelectors do: [ :s | aComponent removeSelector: s ]
 ]
 
 { #category : #'code generation' }
 MolComponentFactory >> removeOldUsedParametersAndServicesComponentAccessorsFor: aComponent [
- 	"remove old used parameters but not the existing or used services"
-	| toBeRemoveProviderSelectors |
-	toBeRemoveProviderSelectors := (aComponent selectors select:[ :s |  'get*Provider' match: (s asString)]) asOrderedCollection.
-	
+	"remove old used parameters but not the existing or used services"
+
+	| toBeRemoveProviderSelectors toPreserve |
+	toBeRemoveProviderSelectors := (aComponent selectors select: [ :s |
+		                                'get*Provider' match: s asString ])
+		                               asOrderedCollection.
+
 	"check if the selectors are already in the current used parameters or used services, in case don't remove them"
-	aComponent haveComponentType ifTrue:[
-		aComponent componentType usedComponentParameters do:[ :e | 
-			toBeRemoveProviderSelectors copy do:[ :sel | ('get', e printString, 'Provider' = sel) ifTrue:[toBeRemoveProviderSelectors remove: sel]].
-		].
-		aComponent componentType usedComponentServices do:[ :e | 
-			toBeRemoveProviderSelectors copy do:[ :sel | ('get', e printString, 'Provider' = sel) ifTrue:[toBeRemoveProviderSelectors remove: sel]].
-		].
-	].
-	
-	toBeRemoveProviderSelectors do:[ :s | aComponent removeSelector: s].
+	aComponent haveComponentType ifTrue: [
+		toPreserve := Set new.
+		toPreserve addAll: aComponent componentType usedComponentParameters.
+		toPreserve addAll: aComponent usedComponentParameters.
+		toPreserve addAll: aComponent componentType usedComponentServices.
+		toPreserve addAll: aComponent usedComponentServices.
+
+		toPreserve do: [ :e |
+			toBeRemoveProviderSelectors copy do: [ :sel |
+				'get' , e printString , 'Provider' = sel ifTrue: [
+					toBeRemoveProviderSelectors remove: sel ] ] ]].
+
+	toBeRemoveProviderSelectors do: [ :s | aComponent removeSelector: s ]
 ]

--- a/src/Molecule/MolUtils.class.st
+++ b/src/Molecule/MolUtils.class.st
@@ -67,11 +67,21 @@ MolUtils class >> componentType: aComponentOrComponentClass [
 { #category : #'component contract' }
 MolUtils class >> consumedComponentEvents: anObject [
 	"Get consumed events of an object, return nil if no events was found"
-	
-	| componentType |
-	anObject isTrait ifFalse: [ (self isComponentOrComponentClass: anObject) ifFalse: [ ^ {} ] ]. 
-	componentType := (anObject isTrait and:[ anObject isComponentType]) ifTrue:[ anObject ] ifFalse: [ self componentType: anObject ].
-	^ componentType ifNotNil: [ :e | ^ e consumedComponentEvents ] ifNil: [ ^ {} ]
+
+	| componentType set |
+	anObject isTrait ifFalse: [
+		(self isComponentOrComponentClass: anObject) ifFalse: [ ^ {  } ] ].
+	componentType := (anObject isTrait and: [ anObject isComponentType ])
+		                 ifTrue: [ anObject ]
+		                 ifFalse: [ self componentType: anObject ].
+	^ componentType
+		  ifNotNil: [ :e | set := Set new.
+			  (anObject class respondsTo: #consumedComponentEvents)
+				  ifTrue: [ set addAll: anObject class consumedComponentEvents ]
+				  ifFalse: [ set addAll: anObject consumedComponentEvents ].
+			  set addAll: e consumedComponentEvents.
+			  ^ set asArray  ]
+		  ifNil: [ ^ {  } ]
 ]
 
 { #category : #'quick creation' }
@@ -253,31 +263,62 @@ MolUtils class >> passivateComponents: aComponentClassList [
 { #category : #'component contract' }
 MolUtils class >> producedComponentEvents: anObject [
 	"Get produced events of an object, return nil if no events was found"
-	
-	| componentType |
-	anObject isTrait ifFalse: [ (self isComponentOrComponentClass: anObject) ifFalse: [ ^ {} ] ]. 
-	componentType := (anObject isTrait and:[ anObject isComponentType]) ifTrue:[ anObject ] ifFalse: [ self componentType: anObject ].
-	^ componentType ifNotNil: [ :e | ^ e producedComponentEvents ] ifNil: [ ^ {} ]
+
+	| componentType set |
+	anObject isTrait ifFalse: [
+		(self isComponentOrComponentClass: anObject) ifFalse: [ ^ {  } ] ].
+	componentType := (anObject isTrait and: [ anObject isComponentType ])
+		                 ifTrue: [ anObject ]
+		                 ifFalse: [ self componentType: anObject ].
+	^ componentType
+		  ifNotNil: [ :e | set := Set new.
+			  (anObject class respondsTo: #producedComponentEvents)
+				  ifTrue: [
+				  set addAll: anObject class producedComponentEvents ]
+				  ifFalse: [ set addAll: anObject producedComponentEvents ].
+			  set addAll: e producedComponentEvents.
+			  ^ set asArray  ]
+		  ifNil: [ ^ {  } ]
 ]
 
 { #category : #'component contract' }
 MolUtils class >> providedComponentParameters: anObject [
 	"Get provided parameters of an object, return nil if no parameters was found"
-	
-	| componentType |
-	anObject isTrait ifFalse: [ (self isComponentOrComponentClass: anObject) ifFalse: [ ^ {} ] ]. 
-	componentType := (anObject isTrait and:[ anObject isComponentType]) ifTrue:[ anObject ] ifFalse: [ self componentType: anObject ].
-	^ componentType ifNotNil: [ :e | ^ e providedComponentParameters ] ifNil: [ ^ {} ]
+
+	| componentType set |
+	anObject isTrait ifFalse: [
+		(self isComponentOrComponentClass: anObject) ifFalse: [ ^ {  } ] ].
+	componentType := (anObject isTrait and: [ anObject isComponentType ])
+		                 ifTrue: [ anObject ]
+		                 ifFalse: [ self componentType: anObject ].
+	^ componentType
+		  ifNotNil: [ :e | set := Set new.
+			  (anObject class respondsTo: #providedComponentParameters)
+				  ifTrue: [ set addAll: anObject class providedComponentParameters ]
+				  ifFalse: [ set addAll: anObject providedComponentParameters ].
+			  set addAll: e providedComponentParameters.
+			  ^ set asArray ]
+		  ifNil: [ ^ {  } ]
 ]
 
 { #category : #'component contract' }
 MolUtils class >> providedComponentServices: anObject [
 	"Get provided services of an object, return nil if no services was found"
+
+	| componentType set |
+	anObject isTrait ifFalse: [
+		(self isComponentOrComponentClass: anObject) ifFalse: [ ^ {  } ] ].
+	componentType := (anObject isTrait and: [ anObject isComponentType ])
+		                 ifTrue: [ anObject ]
+		                 ifFalse: [ self componentType: anObject ].
 	
-	| componentType |
-	anObject isTrait ifFalse: [ (self isComponentOrComponentClass: anObject) ifFalse: [ ^ {} ] ]. 
-	componentType := (anObject isTrait and:[ anObject isComponentType]) ifTrue:[ anObject ] ifFalse: [ self componentType: anObject ].
-	^ componentType ifNotNil: [ :e | ^ e providedComponentServices ] ifNil: [ ^ {} ]
+	^ componentType
+		  ifNotNil: [ :e | set := Set new.	
+	(anObject class respondsTo: #providedComponentServices) ifTrue:[
+	set addAll: anObject class providedComponentServices] ifFalse:[set addAll: anObject providedComponentServices].
+	set addAll: e providedComponentServices.
+	^set asArray. ]
+		  ifNil: [ ^ {  } ]
 ]
 
 { #category : #'quick lifecycle' }
@@ -413,19 +454,39 @@ MolUtils class >> toggleLog [
 { #category : #'component contract' }
 MolUtils class >> usedComponentParameters: anObject [
 	"Get used parameters of an object, return nil if no parameters was found"
-	
-	| componentType |
-	anObject isTrait ifFalse: [ (self isComponentOrComponentClass: anObject) ifFalse: [ ^ {} ] ]. 
-	componentType := (anObject isTrait and:[ anObject isComponentType]) ifTrue:[ anObject ] ifFalse: [ self componentType: anObject ].
-	^ componentType ifNotNil: [ :e | ^ e usedComponentParameters ] ifNil: [ ^ {} ]
+
+	| componentType set |
+	anObject isTrait ifFalse: [
+		(self isComponentOrComponentClass: anObject) ifFalse: [ ^ {  } ] ].
+	componentType := (anObject isTrait and: [ anObject isComponentType ])
+		                 ifTrue: [ anObject ]
+		                 ifFalse: [ self componentType: anObject ].
+	^ componentType
+		  ifNotNil: [ :e | set := Set new.
+			  (anObject class respondsTo: #usedComponentParameters)
+				  ifTrue: [ set addAll: anObject class usedComponentParameters ]
+				  ifFalse: [ set addAll: anObject usedComponentParameters ].
+			  set addAll: e usedComponentParameters.
+			  ^ set asArray ]
+		  ifNil: [ ^ {  } ]
 ]
 
 { #category : #'component contract' }
 MolUtils class >> usedComponentServices: anObject [
 	"Get used services of an object, return nil if no services was found"
-	
-	| componentType |
-	anObject isTrait ifFalse: [ (self isComponentOrComponentClass: anObject) ifFalse: [ ^ {} ] ]. 
-	componentType := (anObject isTrait and:[ anObject isComponentType]) ifTrue:[ anObject ] ifFalse: [ self componentType: anObject ].
-	^ componentType ifNotNil: [ :e | ^ e usedComponentServices ] ifNil: [ ^ {} ]
+
+	| componentType set |
+	anObject isTrait ifFalse: [
+		(self isComponentOrComponentClass: anObject) ifFalse: [ ^ {  } ] ].
+	componentType := (anObject isTrait and: [ anObject isComponentType ])
+		                 ifTrue: [ anObject ]
+		                 ifFalse: [ self componentType: anObject ].
+	^ componentType
+		  ifNotNil: [ :e | set := Set new.
+			  (anObject class respondsTo: #usedComponentServices)
+				  ifTrue: [ set addAll: anObject class usedComponentServices ]
+				  ifFalse: [ set addAll: anObject usedComponentServices ].
+			  set addAll: e usedComponentServices.
+			  ^ set asArray  ]
+		  ifNil: [ ^ {  } ]
 ]


### PR DESCRIPTION
Component implementations can overload component contract to fullfill operational executions, eg: a Calculator component type can have a ScientificCalculatorImpl or SolarCalculatorImpl which can  define specific overload for the impl in a project or a project line.  